### PR TITLE
GraalVM native image tweaks

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,6 +12,8 @@
                         "-J-Dclojure.spec.skip-macros=true"
                         "-J-Dclojure.compiler.direct-linking=true"
                         "-H:IncludeResources=clj_kondo/impl/cache/built_in/.*/.*transit.json$"
+                        "-H:ReflectionConfigurationFiles=reflection.json"
+                        "--initialize-at-build-time"
                         "-H:Log=registerResource:"
                         "--verbose"
                         "-J-Xmx3g"]
@@ -20,7 +22,7 @@
              {:local/root "/Users/Borkdude/git/clj.native-image"}}
             {clj.native-image
              {:git/url "https://github.com/taylorwood/clj.native-image.git"
-              :sha "498baa963e914fd817dbf33ea251729efd0c8f95"}}}
+              :sha "567176ddb0f7507c8b0969e0a10f60f848afaf7d"}}}
            :test
            {:extra-deps
             {test-runner

--- a/reflection.json
+++ b/reflection.json
@@ -1,0 +1,9 @@
+[
+    {
+        "name": "java.lang.Class",
+        "allDeclaredConstructors": true,
+        "allPublicConstructors": true,
+        "allDeclaredMethods": true,
+        "allPublicMethods": true
+    }
+]


### PR DESCRIPTION
I checked out this project from https://github.com/taylorwood/clj.native-image/issues/5 and made a couple tweaks to get it building with GraalVM 19.0.0.

Running clj-kondo native image on itself:
```
➜  clj-kondo git:(native-image-fix) /usr/bin/time -l ./clj-kondo --lint .
./corpus/cljc/datascript.cljc:8:1: error: wrong number of args (2) passed to datascript.db/seqable?
8<------------------------------------------
./src/clj_kondo/main.clj:5:5: warning: unused namespace clj-kondo.impl.rewrite-clj-patch
linting took 560ms, errors: 39, warnings: 23
        0.58 real         0.42 user         0.12 sys
 258760704  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
     63262  page reclaims
         0  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
        84  voluntary context switches
       120  involuntary context switches
```
I didn't touch the `-Dclojure.compiler.direct-linking=true` options though they probably should be tweaked per https://github.com/taylorwood/clj.native-image/issues/5.