### PR TITLE
lint keyword calls

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -425,11 +425,14 @@
 (defn lint-keyword-call! [ctx kw namespaced? arg-count expr]
   (let [ns (:ns ctx)
         ?resolved-ns (if namespaced?
-                       (let [kw-ns (namespace kw)]
+                       (if-let [kw-ns (namespace kw)]
                          (or (get (:qualify-ns ns) (symbol kw-ns))
                              ;; because we couldn't resolve the namespaced
                              ;; keyword, we print it as is
-                             (str ":" (namespace kw))))
+                             (str ":" (namespace kw)))
+                         ;; if the keyword is namespace, but there is no
+                         ;; namespace, it's the current ns
+                         (:name ns))
                        (namespace kw))
         kw-str (if ?resolved-ns (str ?resolved-ns "/" (name kw))
                    (str (name kw)))]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -443,13 +443,15 @@
                                               arg-count
                                               kw-str))))))
 
-(defn analyze-clojure-call [{:keys [:filename :fn-body :base-lang :lang :ns] :as ctx}
-                            {:keys [:arg-count
-                                    :resolved-namespace
-                                    :resolved-name
-                                    :resolved-as-clojure-var-name
-                                    :full-fn-name
-                                    :row :col]} expr]
+(defn analyze-core-call
+  [{:keys [:filename :fn-body :base-lang :lang :ns] :as ctx}
+   {:keys [:arg-count
+           :resolved-namespace
+           :resolved-name
+           :resolved-as-clojure-var-name
+           :full-fn-name
+           :row :col
+           :expr]}]
   (let [children (:children expr)]
     (case resolved-as-clojure-var-name
       ns
@@ -597,15 +599,17 @@
                              :lang lang
                              :expr expr})]
                   (cons* use
-                         (analyze-clojure-call ctx
-                                               {:arg-count arg-count
-                                                :resolved-namespace resolved-namespace
-                                                :resolved-name resolved-name
-                                                :resolved-as-clojure-var-name resolved-as-clojure-var-name
-                                                :full-fn-name full-fn-name
-                                                :row row
-                                                :col col}
-                                               expr)))))
+                         (analyze-core-call ctx
+                                            {:arg-count arg-count
+                                             :resolved-namespace resolved-namespace
+                                             :resolved-name resolved-name
+                                             :resolved-as-clojure-var-name resolved-as-clojure-var-name
+                                             :full-fn-name full-fn-name
+                                             :row row
+                                             :col col
+                                             :expr expr})))))
+            ;; TODO: emit errors when something not callable, e.g. a string or
+            ;; number is in function position
             (analyze-children ctx children))))
       (analyze-children ctx children))))
 

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -2,7 +2,7 @@
   {:no-doc true}
   (:require
    [clj-kondo.impl.utils :refer [some-call node->line
-                                 tag call parse-string
+                                 tag symbol-call parse-string
                                  constant?]]
    [rewrite-clj.node.protocols :as node]
    [clj-kondo.impl.var-info :as var-info]
@@ -34,7 +34,7 @@
        (redundant-do* parsed-expressions false)))
 
 (defn lint-def* [filename expr in-def?]
-  (let [fn-name (call expr)
+  (let [fn-name (symbol-call expr)
         simple-fn-name (when fn-name (symbol (name fn-name)))]
     ;; TODO: it would be nicer if we could have the qualified calls of this expression somehow
     ;; so we wouldn't have to deal with these primitive expressions anymore

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -17,13 +17,24 @@
 (defn comment? [node]
   (= :comment (tag node)))
 
-(defn call
+(defn symbol-call
   "Returns symbol of call"
   [expr]
   (when (= :list (node/tag expr))
-    (let [?sym (-> expr :children first :value)]
+    (let [first-child (-> expr :children first)
+          ?sym (:value first-child)]
       (when (symbol? ?sym)
         ?sym))))
+
+(defn keyword-call
+  "Returns keyword of call"
+  [expr]
+  (when (= :list (node/tag expr))
+    (let [first-child (-> expr :children first)
+          ?k (:k first-child)]
+      (when (keyword? ?k)
+        {:k ?k
+         :namespaced? (:namespaced? first-child)}))))
 
 (defmacro some-call
   "Determines if expr is a call to some symbol. Returns symbol if so."

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1000,7 +1000,14 @@
       :col 10
       :level :error,
       :message "wrong number of args (3) passed to keyword ::b/x"})
-   (lint! "(ns foo) (::b/x {:bar/x 1} 1 2)")))
+   (lint! "(ns foo) (::b/x {:bar/x 1} 1 2)"))
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 10,
+      :level :error,
+      :message "wrong number of args (3) passed to keyword :foo/x"})
+   (lint! "(ns foo) (::x {::x 1} 2 3)")))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -972,6 +972,36 @@
   (is (empty? (lint! "(for [select-keys []] (select-keys 1))")))
   (is (empty? (lint! "(doseq [select-keys []] (select-keys 1))"))))
 
+(deftest keyword-call-test
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 1,
+      :level :error,
+      :message "wrong number of args (3) passed to keyword :x"})
+   (lint! "(:x 1 2 3)"))
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 10,
+      :level :error,
+      :message "wrong number of args (3) passed to keyword :b/x"})
+   (lint! "(ns foo) (:b/x {:bar/x 1} 1 2)"))
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 33,
+      :level :error,
+      :message "wrong number of args (3) passed to keyword :bar/x"})
+   (lint! "(ns foo (:require [bar :as b])) (::b/x {:bar/x 1} 1 2)"))
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 10
+      :level :error,
+      :message "wrong number of args (3) passed to keyword ::b/x"})
+   (lint! "(ns foo) (::b/x {:bar/x 1} 1 2)")))
+
 ;;;; Scratch
 
 (comment


### PR DESCRIPTION
- [x] Fix: echo '(::foo 1 2 3)' | clj-kondo --lint -