### PR TITLE
Advocate use of `clojure` over `clj`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ clj-kondo --lint "<classpath>" --cache
 Build tool specific ways to get a classpath:
 - `lein classpath`
 - `boot with-cp -w -f`
-- `clj -Spath`
+- `clojure -Spath`
 
 So for `lein` the entire command would be:
 


### PR DESCRIPTION
`clj` uses rlwrap, which will produce a warning in CI environments
as it's not a terminal where rlwrap can be used.  For this exact
use-case, `clojure` is more than fine, as rlwrap is not necessary for
the `-Spath` option.