### PR TITLE
Add information on how to get the version of clj-kondo in use

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **version**
 
-[ Please specify which version of clj-kondo you're using.]
+[ Please specify which version of clj-kondo you're using. You can find this with `clj-kondo --version`.]
 
 **platform**
 


### PR DESCRIPTION
This makes it more likely that people will try and find the right version.