### PR TITLE
Correctly analyze `clojure.core/when-first` macro

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -908,7 +908,7 @@
           (analyze-like-let ctx expr)
           letfn
           (analyze-letfn ctx expr)
-          (if-let if-some when-let when-some)
+          (if-let if-some when-let when-some when-first)
           (analyze-if-let ctx expr)
           do
           (analyze-do ctx expr)


### PR DESCRIPTION
Hey @borkdude, here's the tiny fix we talked about yesterday at heartofclojure. I wanted to add some sort of test for it but I don't know where would be the best place to do so. Maybe I just add this line to `corpus/unresolved_symbol.clj`:

```clj
(when-first [a [1 2 3]] a)
```

wdyt?