### PR TITLE
Support PATH native-image on *nix-likes

### DIFF
--- a/script/compile
+++ b/script/compile
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
 
-if [ -z "$GRAALVM_HOME" ]; then
-    echo "Please set GRAALVM_HOME"
-    exit 1
-fi
+NATIVE_IMAGE=`which native-image`
+
+if [ -z "$NATIVE_IMAGE" ]; then
+  if [ -z "$GRAALVM_HOME" ]; then
+      echo "Please set GRAALVM_HOME"
+      exit 1
+  fi
 
 # mkdir -p target/classes
 # javac java-src/clj_kondo/LockFix.java \
 #       -cp ~/.m2/repository/org/clojure/clojure/1.10.0/clojure-1.10.0.jar \
 #       -d target/classes
 
-"$GRAALVM_HOME/bin/gu" install native-image
+  "$GRAALVM_HOME/bin/gu" install native-image
+
+  NATIVE_IMAGE="$GRAALVM_HOME/bin/native-image"
+fi
 
 CLJ_KONDO_VERSION=$(cat resources/CLJ_KONDO_VERSION)
 
 lein with-profiles +clojure-1.10.1 do clean, uberjar
-$GRAALVM_HOME/bin/native-image \
+$NATIVE_IMAGE \
   -jar target/clj-kondo-$CLJ_KONDO_VERSION-standalone.jar \
   -H:Name=clj-kondo \
   -H:+ReportExceptionStackTraces \


### PR DESCRIPTION
Attempt to use native-image from PATH on *nix-like systems.

Tested locally on machine with native-image on PATH.  I don't have a local setup to fully test the other path -- where there is no native-image on PATH.