### PR TITLE
Use namespace's local config when running `lint-unused-namespaces!`

### DIFF
--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -306,7 +306,8 @@
                 referred-vars (:referred-vars ns)
                 used-referred-vars (:used-referred-vars ns)
                 refer-alls (:refer-alls ns)
-                filename (:filename ns)]]
+                filename (:filename ns)
+                config (config/merge-config! config (:config ns))]]
     (doseq [ns-sym unused]
       (when-not (config/unused-namespace-excluded config ns-sym)
         (let [{:keys [:row :col :filename]} (meta ns-sym)]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1149,7 +1149,11 @@
   (is (empty? (lint! (io/file "corpus" "no_unused_namespace.clj"))))
   (is (empty? (lint! "(ns foo (:require [bar :as b])) (let [{::b/keys [:baz]} nil] baz)")))
   (is (empty? (lint! "(require '[clojure.set :refer [join]]) join")))
-  (is (empty? (lint! "(ns foo (:require [bar :as b])) (let [{:keys [::b/x]} {}] x)"))))
+  (is (empty? (lint! "(ns foo (:require [bar :as b])) (let [{:keys [::b/x]} {}] x)")))
+  (is (empty? (lint! "(ns ^{:clj-kondo/config
+                            '{:linters {:unused-namespace {:exclude [bar]}}}}
+                          foo
+                        (:require [bar :as b]))"))))
 
 (deftest namespace-syntax-test
   (assert-submaps '({:file "<stdin>",
@@ -2100,7 +2104,11 @@
    (lint! "(ns foo (:require [bar :refer [bar]]))"
           '{:linters {:unused-referred-var {:exclude {bar [bar]}}}}))
   (is (empty? (lint! "(ns foo (:require [bar :refer [bar]]))
-        (apply bar 1 2 [3 4])"))))
+        (apply bar 1 2 [3 4])")))
+  (is (empty? (lint! "(ns ^{:clj-kondo/config
+                            '{:linters {:unused-referred-var {:exclude {foo [bar]}}}}}
+                          foo (:require [foo :refer [bar] :as foo]))
+        (apply foo/x 1 2 [3 4])"))))
 
 (deftest duplicate-require-test
   (assert-submaps


### PR DESCRIPTION
**version**

clj-kondo v2019.08.01-alpha-SNAPSHOT

**platform**

Linux, GraalVM

**problem**

Namespaces local config in the metadata was ignored when registering findings for `:unused-namespace` and `:unused-referred-var`.

**repro**

```bash
$> clj-kondo --lint - << EOF
(ns ^{:clj-kondo/config
      '{:linters {:unused-namespace {:exclude [clojure.pprint]}
                  :unused-referred-var {:exclude {clojure.pprint [pprint]}}}}}
    user
  (:require [clojure.pprint :refer [pprint]]))
EOF
<stdin>:5:14: warning: namespace clojure.pprint is required but never used
<stdin>:5:37: warning: #'clojure.pprint/pprint is referred but never used
linting took 26ms, errors: 0, warnings: 2
```

**expected behavior**

No warnings

---

Not sure if the tests I added are the most convenient or if there's a different place where this could be tested.  Feel free to let me know and I can adjust whatever's necessary :)