### PR TITLE
Add default linter for `clojure.test.check.generators/let`

### DIFF
--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -64,6 +64,7 @@
               cats.core/->>= clojure.core/->>
               rewrite-clj.custom-zipper.core/defn-switchable clojure.core/defn
               clojure.core.async/go-loop clojure.core/loop
+              clojure.test.check.generators/let clojure.core/let
               cljs.core.async/go-loop clojure.core/loop
               cljs.core.async.macros/go-loop clojure.core/loop}
     :output {:format :text ;; or :edn


### PR DESCRIPTION
@borkdude Not sure if this is interesting for you to add to the default configuration, but just in case :) feel free to close it if you prefer not to provide a default linter for `clojure.test.check.generators/let`

In the current implementation:

```bash
$> clj-kondo --lint - << EOF
(ns test
  (:require [clojure.test.check.generators :as gen]))
(gen/let [x 1] x) 
EOF
<stdin>:3:11: info: unresolved symbol x
linting took 24ms, errors: 0, warnings: 0
```

This PR removes the false positive.