### PR TITLE
[WIP] Propagate error locations of read errors

### DIFF
--- a/corpus/read_error/EOF.clj
+++ b/corpus/read_error/EOF.clj
@@ -1,0 +1,1 @@
+(ns read-error.EOF

--- a/corpus/read_error/error.clj
+++ b/corpus/read_error/error.clj
@@ -1,1 +1,0 @@
-(ns read-error.error

--- a/corpus/read_error/invalid_keyword.clj
+++ b/corpus/read_error/invalid_keyword.clj
@@ -1,0 +1,3 @@
+(ns read-error.invalid-keyword)
+
+:

--- a/corpus/read_error/invalid_number.clj
+++ b/corpus/read_error/invalid_number.clj
@@ -1,0 +1,4 @@
+(ns read-error.invalid-number)
+
+
+100Z

--- a/corpus/read_error/invalid_symbol.clj
+++ b/corpus/read_error/invalid_symbol.clj
@@ -1,0 +1,5 @@
+(ns read-error.invalid-symbol)
+
+clojure.core/
+
+(let [x 0]) ;; <= TODO progress past read errors to other warnings?

--- a/corpus/read_error/invalid_unicode.clj
+++ b/corpus/read_error/invalid_unicode.clj
@@ -1,0 +1,4 @@
+(ns read-error.invalid-unicode)
+
+
+\u12345


### PR DESCRIPTION
Note: this is only a partial solution, and only displays error location for invalid keywords.
I'm not familiar enough with the codebase or implementation details to know how to proceed, perhaps some pointers would be helpful.
Or simply treat this PR as reference if it's easier for someone else to pick it up themselves :)

What I found was that the tools.reader exceptions have optional `:line` and `:col` keys attached to them, but it seems like only invalid keywords actually produce this information, due to some difference between `IndexingPushbackReader` and `PushbackReader`.

Also, read-time errors aren't all thrown from the same place, most come from clojure.tools.reader but some like "unexpected EOF" are thrown from `rewrite-clj`.

