### PR TITLE
Fix #446: Handle using required namespace as object in Cljs

### DIFF
--- a/corpus/cljs_ns_as_as_object.cljs
+++ b/corpus/cljs_ns_as_as_object.cljs
@@ -1,0 +1,5 @@
+(ns foo
+  (:require [reagent.core :as r]
+            ["apsl-react-native-button" :as NativeButton]))
+
+(def button (r/adapt-react-class NativeButton))

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -204,6 +204,10 @@
          {:ns java-class
           :java-interop? true
           :name name-sym})
+       (if (= :cljs lang)
+         (if-let [ns* (get (:qualify-ns ns) name-sym)]
+           {:ns ns*
+            :name name-sym}))
        (let [clojure-excluded? (contains? (:clojure-excluded ns)
                                           name-sym)
              core-sym? (when-not clojure-excluded?

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1158,7 +1158,8 @@
   (is (empty? (lint! "(ns ^{:clj-kondo/config
                             '{:linters {:unused-namespace {:exclude [bar]}}}}
                           foo
-                        (:require [bar :as b]))"))))
+                        (:require [bar :as b]))")))
+  (is (empty? (lint! (io/file "corpus" "cljs_ns_as_as_object.cljs")))))
 
 (deftest namespace-syntax-test
   (assert-submaps '({:file "<stdin>",


### PR DESCRIPTION
In Cljs, check if a name referes to a namespace alias directly.