### PR TITLE
Add alias / :as to analysis data

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -27,6 +27,7 @@ The analysis output consists of a map with:
    - `:filename`, `:row`, `:col`
    - `:from`: the namespace which uses
    - `:to`: the used namespace
+   - `:as`: the alias of namespace, if used
 
 - `:var-definitions`, a list of maps with:
   - `:filename`, `:row`, `:col`
@@ -61,7 +62,7 @@ Example output after linting this code:
   {:deprecated "1.3"
    :author "Michiel Borkent"
    :no-doc true}
-  (:require [clojure.set]))
+  (:require [clojure.set :as set]))
 
 (defn- f [x]
   (inc x))
@@ -90,7 +91,8 @@ $ clj-kondo --lint /tmp/foo.clj --config '{:output {:analysis true :format :edn}
                      :row 6,
                      :col 14,
                      :from foo,
-                     :to clojure.set}],
+                     :to clojure.set,
+                     :as set}],
  :var-definitions [{:filename "/tmp/foo.clj",
                     :row 8,
                     :col 1,

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -52,7 +52,7 @@
           :lang (when (= :cljc base-lang) lang))))
 
 (defn reg-namespace-usage! [{:keys [:analysis :base-lang :lang] :as _ctx}
-                            filename row col from-ns to-ns]
+                            filename row col from-ns to-ns as]
   (swap! analysis update :namespace-usages conj
          (assoc-some
           {:filename filename
@@ -60,4 +60,5 @@
            :col col
            :from from-ns
            :to to-ns}
-          :lang (when (= :cljc base-lang) lang))))
+          :lang (when (= :cljc base-lang) lang)
+          :as as)))

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -52,7 +52,7 @@
           :lang (when (= :cljc base-lang) lang))))
 
 (defn reg-namespace-usage! [{:keys [:analysis :base-lang :lang] :as _ctx}
-                            filename row col from-ns to-ns as]
+                            filename row col from-ns to-ns alias]
   (swap! analysis update :namespace-usages conj
          (assoc-some
           {:filename filename
@@ -61,4 +61,4 @@
            :from from-ns
            :to to-ns}
           :lang (when (= :cljc base-lang) lang)
-          :as as)))
+          :alias alias)))

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -197,8 +197,9 @@
                            {}
                            analyzed)]
     (lint-duplicate-requires! ctx (map (juxt :require-kw :ns) analyzed))
-    {:required (map :ns analyzed)
-     :aliases (into {} (map (juxt :ns :as) (filter :as analyzed)))
+    {:required (map (fn [req]
+                      (vary-meta (:ns req)
+                                 #(assoc % :alias (:as req)))) analyzed)
      :qualify-ns (reduce (fn [acc sc]
                            (cond-> (assoc acc (:ns sc) (:ns sc))
                              (:as sc)
@@ -322,9 +323,9 @@
                                                          :no-doc (:no-doc ns-meta)
                                                          :author (:author ns-meta)))
       (doseq [req (:required ns)]
-        (let [{:keys [row col]} (meta req)]
-          (analysis/reg-namespace-usage! ctx filename row col ns-name req
-                                         (get-in ns [:aliases req])))))
+        (let [{:keys [row col alias]} (meta req)]
+          (analysis/reg-namespace-usage! ctx filename row col ns-name
+                                         req alias))))
     (namespace/reg-namespace! ctx ns)
     ns))
 

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -198,6 +198,7 @@
                            analyzed)]
     (lint-duplicate-requires! ctx (map (juxt :require-kw :ns) analyzed))
     {:required (map :ns analyzed)
+     :aliases (into {} (map (juxt :ns :as) (filter :as analyzed)))
      :qualify-ns (reduce (fn [acc sc]
                            (cond-> (assoc acc (:ns sc) (:ns sc))
                              (:as sc)
@@ -322,7 +323,8 @@
                                                          :author (:author ns-meta)))
       (doseq [req (:required ns)]
         (let [{:keys [row col]} (meta req)]
-          (analysis/reg-namespace-usage! ctx filename row col ns-name req))))
+          (analysis/reg-namespace-usage! ctx filename row col ns-name req
+                                         (get-in ns [:aliases req])))))
     (namespace/reg-namespace! ctx ns)
     ns))
 

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -73,7 +73,7 @@
                 :namespace-usages
                 :var-usages
                 :var-definitions]}
-        (analyze "(ns foo (:require [clojure.string]))
+        (analyze "(ns foo (:require [clojure.string :as string]))
                   (defn f [] (inc 1 2 3))" {:lang :cljc})]
     (assert-submaps
      '[{:filename "<stdin>", :row 1, :col 1, :name foo, :lang :clj}
@@ -85,12 +85,14 @@
         :col 20,
         :from foo,
         :to clojure.string,
+        :as string
         :lang :clj}
        {:filename "<stdin>",
         :row 1,
         :col 20,
         :from foo,
         :to clojure.string,
+        :as string
         :lang :cljs}]
      namespace-usages)
     (assert-submaps
@@ -148,4 +150,7 @@
         :arity 3,
         :row 2,
         :to cljs.core}]
-     var-usages)))
+     var-usages))
+  (let [{:keys [:namespace-usages]}
+        (analyze "(ns foo (:require [clojure.string]))" {:lang :cljc})]
+    (is (every? #(not (contains? % :as)) namespace-usages))))

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -85,14 +85,14 @@
         :col 20,
         :from foo,
         :to clojure.string,
-        :as string
+        :alias string
         :lang :clj}
        {:filename "<stdin>",
         :row 1,
         :col 20,
         :from foo,
         :to clojure.string,
-        :as string
+        :alias string
         :lang :cljs}]
      namespace-usages)
     (assert-submaps


### PR DESCRIPTION
This would be useful for:

- Auto-inserting the require based on existing aliases (e.g. str/ should
insert clojure.string)
- Ensuring a consistent use of aliases in a project.