### PR TITLE
Fix partition signature when 4 parameters provided

### DIFF
--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -236,7 +236,7 @@
                             :ret :seqable}
                          3 {:args [:int :int :seqable]
                             :ret :seqable}
-                         4 {:args [:int :int :int :seqable]
+                         4 {:args [:int :int :seqable :seqable]
                             :ret :seqable}}}
    ;; 4105
    'set {:ret :set}


### PR DESCRIPTION
`clj-kondo --lint - <<< '(partition 10 10 nil [1 2 3 4])'`

should now work correctly. Third parameter (pad) is a collection.

