### PR TITLE
Error messages should point to the opening paren, not EOF

### DIFF
--- a/parser/clj_kondo/impl/rewrite_clj/parser/core.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/core.clj
@@ -12,14 +12,22 @@
 
 ;; ## Base Parser
 
+
 (def ^:dynamic ^:private *delimiter*
+  "Record information about the pair of delimiter that are being parsed.
+  This keeps track when parsing matching pairs of `{}`, `[]`, `()`.
+  Store a tuple of 4 values: [open (char), close (char), row (int), col (int)]
+  - The first item is the opening character, `{`, `[` or `(`.
+  - The second item is the closing character, `}`, `]` or `)`.
+  - The third item is the row on which the opening bracket was found.
+  - The fourth item is the column on which the opening bracket was found."
   nil)
 
 (defn- dispatch
   [c]
-  (cond (nil? c)               :eof
-        (reader/whitespace? c) :whitespace
-        (= c *delimiter*)      :delimiter
+  (cond (nil? c)                   :eof
+        (reader/whitespace? c)     :whitespace
+        (= c (second *delimiter*)) :delimiter
         :else (get {\^ :meta      \# :sharp
                     \( :list      \[ :vector    \{ :map
                     \} :unmatched \] :unmatched \) :unmatched
@@ -38,11 +46,12 @@
 ;; # Parser Helpers
 
 (defn- parse-delim
-  [reader delimiter]
-  (reader/ignore reader)
-  (->> #(binding [*delimiter* delimiter]
-          (parse-next %))
-       (reader/read-repeatedly reader)))
+  [reader open-delimiter close-delimiter]
+  (let [{:keys [row col]} (reader/position reader :row :col)]
+    (reader/ignore reader)
+    (->> #(binding [*delimiter* [open-delimiter close-delimiter row col]]
+            (parse-next %))
+         (reader/read-repeatedly reader))))
 
 (defn- parse-printables
   [reader node-tag n & [ignore?]]
@@ -69,15 +78,29 @@
 
 (defmethod parse-next* :unmatched
   [reader]
-  (u/throw-reader
-   reader
-   "Unmatched delimiter: %s"
-   (reader/peek reader)))
+  (let [[open _ row col] *delimiter*
+        {:keys [close-row close-col]} (reader/position reader :close-row :close-col)
+        closer (reader/peek reader)
+        open-message (format "Mismatched brackets found an opening %s and a closing %s on line %d" open closer close-row)
+        close-message (format "Mismatched brackets found an opening %s on line %d and a closing %s" open row closer)
+        opening {:row row
+                 :col col
+                 :message open-message}
+        closing  {:row close-row
+                  :col close-col
+                  :message close-message}]
+    (throw (ex-info "Syntax error" {:findings [opening closing]}))))
 
 (defmethod parse-next* :eof
   [reader]
-  (when *delimiter*
-    (u/throw-reader reader "Unexpected EOF.")))
+  (when-let [[open close row col] *delimiter*]
+    (let [opening {:row row
+                   :col col
+                   :message (format "Found an opening %s with no matching %s" open close)}
+          closing (assoc (reader/position reader :row :col)
+                         :message (format "Expected a %s to match %s from line %d" close open row))]
+    (throw (ex-info "Syntax error"
+                    {:findings [opening closing]})))))
 
 ;; ### Whitespace
 
@@ -129,8 +152,8 @@
     \# (read-symbolic-value reader)
     \! (do (reader/read-include-linebreak reader)
            reader)
-    \{ (node/set-node (parse-delim reader \}))
-    \( (node/fn-node (parse-delim reader \)))
+    \{ (node/set-node (parse-delim reader \{ \}))
+    \( (node/fn-node (parse-delim reader \( \)))
     \" (node/regex-node (parse-regex reader))
     \^ (parse-meta reader)
     \' (node/var-node (parse-printables reader :var 1 true))
@@ -188,12 +211,12 @@
 
 (defmethod parse-next* :list
   [reader]
-  (node/list-node (parse-delim reader \))))
+  (node/list-node (parse-delim reader \( \))))
 
 (defmethod parse-next* :vector
   [reader]
-  (node/vector-node (parse-delim reader \])))
+  (node/vector-node (parse-delim reader \[ \])))
 
 (defmethod parse-next* :map
   [reader]
-  (node/map-node (parse-delim reader \})))
+  (node/map-node (parse-delim reader \{ \})))

--- a/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
@@ -25,12 +25,10 @@
 (defn throw-reader
   "Throw reader exception, including line/column."
   [reader fmt & data]
-  (let [c (r/get-column-number reader)
-        l (r/get-line-number reader)]
-    (throw
-     (Exception.
-      (str (apply format fmt data)
-           " [at line " l ", column " c "]")))))
+  (let [f {:row (r/get-line-number reader)
+           :col (r/get-column-number reader)
+           :message (apply format fmt data)}]
+    (throw (ex-info "Syntax error" {:findings [f]}))))
 
 (defn read-eol
   [reader]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1352,29 +1352,24 @@
 
 ;;;; processing of string input
 
-(defn- ->finding
-  "Convert an exception thrown from rewrite-clj into a clj-kondo :finding."
-  [^Exception e ^String filename]
-  (let [m (.getMessage e)]
-    (if-let [[_ msg row col]
-             (and m
-                  (re-find #"(.*)\[at line (\d+), column (\d+)\]"
-                           m))]
-      {:level :error
-       :filename filename
-       :col (Integer/parseInt col)
-       :row (Integer/parseInt row)
-       :type :syntax
-       :message (str/trim msg)}
-      {:level :error
-       :filename filename
-       :col 0
-       :row 0
-       :type :syntax
-       :message (str "can't parse "
-                     filename ", "
-                     (or m (str e)))})))
-
+(defn- ->findings
+  "Convert an exception thrown from rewrite-clj into a sequence clj-kondo :finding"
+  [^Exception ex ^String filename]
+  (if-let [findings (:findings (ex-data ex))]
+    (for [finding findings]
+      (merge {:type :syntax
+              :level :error
+              :filename filename}
+             finding))
+    [{:level :error
+      :filename filename
+      :col 0
+      :row 0
+      :type :syntax
+      :message (str "can't parse "
+                    filename ", "
+                    (or (.getMessage ex) (str ex)))}]))
+  
 (defn analyze-input
   "Analyzes input and returns analyzed defs, calls. Also invokes some
   linters and returns their findings."
@@ -1397,7 +1392,7 @@
       analyzed-expressions)
     (catch Exception e
       (if dev? (throw e)
-          {:findings [(->finding e filename)]}))
+          {:findings (->findings e filename)}))
     (finally
       (let [output-cfg (:output config)]
         (when (and (= :text (:format output-cfg))

--- a/test/clj_kondo/impl/parser_test.clj
+++ b/test/clj_kondo/impl/parser_test.clj
@@ -23,27 +23,34 @@
                      (< thing 0))))))
 
 (defn- parse-error
-  "Parse the source, which is expected to contain a syntax error, and return the
-  error message produced from rewrite-clj."
+  "Parse the source, which is expected to contain a syntax error, and return a
+  sequence of error messages in the form [message line column] produced from
+  rewrite-clj."
   [source]
   (try
     (parse-string source)
     nil
     (catch Exception e
-      (.getMessage e))))
+      (if-let [findings (:findings (ex-data e))]
+        (for [{:keys [row col message]} findings]
+          [message row col])
+        [[(.getMessage e) 0 0]]))))
 
 (deftest parse-string-test
   ;; This test has every syntax error that can cause rewrite-clj to throw using
   ;; the `clj-kondo.impl.rewrite-clj.parser.utils/throw-reader` function.
   ;; This allows us to test for regressions when that function is refactored.
-  (are [source message] (= message (parse-error source))
-    "[" "Unexpected EOF. [at line 1, column 2]"
-    "[}" "Unmatched delimiter: } [at line 1, column 2]"
-    "#" "Unexpected EOF. [at line 1, column 2]"
-    ":" "unexpected EOF while reading keyword. [at line 1, column 2]"
-    "\"" "Unexpected EOF while reading string. [at line 1, column 2]"
-    "#?" ":reader-macro node expects 1 value. [at line 1, column 3]"
-    "#:" "Unexpected EOF. [at line 1, column 3]"))
+  (are [source messages] (= messages (parse-error source))
+    "[" [["Found an opening [ with no matching ]" 1 1]
+         ["Expected a ] to match [ from line 1" 1 2]]
+    "[}"  [["Mismatched brackets found an opening [ and a closing } on line 1" 1 1]
+           ["Mismatched brackets found an opening [ on line 1 and a closing }" 1 2]]
+    "#"  [["Unexpected EOF." 1 2]]
+    ":"  [["unexpected EOF while reading keyword." 1 2]]
+    "\"" [["Unexpected EOF while reading string." 1 2]]
+    "#?" [[":reader-macro node expects 1 value." 1 3]]
+    "[1..1]" [["Invalid number: 1..1." 0 0]]
+    "#:" [["Unexpected EOF." 1 3]]))
 
 ;;;; Scratch
 


### PR DESCRIPTION
Change the vendored copy of rewrite-clj to throw structured data rather
than raw Exception.

Change the analyzer to deal with the structured data rather than the raw
Exceptions, which allows us to remove some regex matching and parsing.

Change the rewrite-clj parser to wrap exceptions when it detects
unmatched delimiters. This allows us to throw multiple errors from a
single error.

Add test for same.