### PR TITLE
Consolidate throw-reader functions

### DIFF
--- a/parser/clj_kondo/impl/rewrite_clj/parser/core.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/core.clj
@@ -5,6 +5,7 @@
     [node :as node]
     [reader :as reader]]
    [clj-kondo.impl.rewrite-clj.parser
+    [utils :as u]
     [keyword :refer [parse-keyword]]
     [string :refer [parse-string parse-regex]]
     [token :refer [parse-token]]]))
@@ -68,7 +69,7 @@
 
 (defmethod parse-next* :unmatched
   [reader]
-  (reader/throw-reader
+  (u/throw-reader
    reader
    "Unmatched delimiter: %s"
    (reader/peek reader)))
@@ -76,7 +77,7 @@
 (defmethod parse-next* :eof
   [reader]
   (when *delimiter*
-    (reader/throw-reader reader "Unexpected EOF.")))
+    (u/throw-reader reader "Unexpected EOF.")))
 
 ;; ### Whitespace
 
@@ -124,7 +125,7 @@
   [reader]
   (reader/ignore reader)
   (case (reader/peek reader)
-    nil (reader/throw-reader reader "Unexpected EOF.")
+    nil (u/throw-reader reader "Unexpected EOF.")
     \# (read-symbolic-value reader)
     \! (do (reader/read-include-linebreak reader)
            reader)

--- a/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
@@ -23,12 +23,14 @@
   nil)
 
 (defn throw-reader
-  [reader & msg]
+  "Throw reader exception, including line/column."
+  [reader fmt & data]
   (let [c (r/get-column-number reader)
         l (r/get-line-number reader)]
     (throw
-      (Exception.
-        (str (apply str msg) " [at line " l ", column " c "]")))))
+     (Exception.
+      (str (apply format fmt data)
+           " [at line " l ", column " c "]")))))
 
 (defn read-eol
   [reader]

--- a/parser/clj_kondo/impl/rewrite_clj/reader.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/reader.clj
@@ -3,20 +3,10 @@
   (:require [clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader
              [edn :as edn]
              [reader-types :as r]]
+            [clj-kondo.impl.rewrite-clj.parser
+              [utils :as u]]
             [clojure.java.io :as io])
   (:import [java.io PushbackReader]))
-
-;; ## Exception
-
-(defn throw-reader
-  "Throw reader exception, including line/column."
-  [reader fmt & data]
-  (let [c (r/get-column-number reader)
-        l (r/get-line-number reader)]
-    (throw
-      (Exception.
-        (str (apply format fmt data)
-             " [at line " l ", column " c "]")))))
 
 ;; ## Decisions
 
@@ -73,7 +63,7 @@
             (str buf)))
         (if eof?
           (str buf)
-          (throw-reader reader "Unexpected EOF."))))))
+          (u/throw-reader reader "Unexpected EOF."))))))
 
 (defn read-until
   "Read until a char fulfills the given condition. Ignores the
@@ -156,7 +146,7 @@
         (recur
           (if (p? v) (inc c) c)
           (conj vs v))
-        (throw-reader
+        (u/throw-reader
           reader
           "%s node expects %d value%s."
           node-tag

--- a/test/clj_kondo/impl/parser_test.clj
+++ b/test/clj_kondo/impl/parser_test.clj
@@ -1,7 +1,7 @@
 (ns clj-kondo.impl.parser-test
   (:require [clj-kondo.impl.parser :as parser :refer [parse-string]]
             [clj-kondo.impl.utils :as utils]
-            [clojure.test :as t :refer [deftest is]]))
+            [clojure.test :as t :refer [deftest is are]]))
 
 (deftest omit-unevals-test
   (is (zero? (count (:children (parse-string "#_#_1 2"))))))
@@ -22,8 +22,31 @@
                 (and (Double/isInfinite thing)
                      (< thing 0))))))
 
+(defn- parse-error
+  "Parse the source, which is expected to contain a syntax error, and return the
+  error message produced from rewrite-clj."
+  [source]
+  (try
+    (parse-string source)
+    nil
+    (catch Exception e
+      (.getMessage e))))
+
+(deftest parse-string-test
+  ;; This test has every syntax error that can cause rewrite-clj to throw using
+  ;; the `clj-kondo.impl.rewrite-clj.parser.utils/throw-reader` function.
+  ;; This allows us to test for regressions when that function is refactored.
+  (are [source message] (= message (parse-error source))
+    "[" "Unexpected EOF. [at line 1, column 2]"
+    "[}" "Unmatched delimiter: } [at line 1, column 2]"
+    "#" "Unexpected EOF. [at line 1, column 2]"
+    ":" "unexpected EOF while reading keyword. [at line 1, column 2]"
+    "\"" "Unexpected EOF while reading string. [at line 1, column 2]"
+    "#?" ":reader-macro node expects 1 value. [at line 1, column 3]"
+    "#:" "Unexpected EOF. [at line 1, column 3]"))
 
 ;;;; Scratch
 
 (comment
+  (t/run-tests)
   )


### PR DESCRIPTION
rewrite-clj has two `throw-reader` functions, with slightly different
behaviour. One expectects a list of strings, the other expects a format
string and matching arguments.

Replace both functions with a single one.

Add a full regression test that has example source code that excercises
all call sites of throw-reader, to ensure that this refactor does not
change behaviour.