### PR TITLE
Better error messages for syntax errors

### DIFF
--- a/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
@@ -25,12 +25,10 @@
 (defn throw-reader
   "Throw reader exception, including line/column."
   [reader fmt & data]
-  (let [c (r/get-column-number reader)
-        l (r/get-line-number reader)]
-    (throw
-     (Exception.
-      (str (apply format fmt data)
-           " [at line " l ", column " c "]")))))
+  (let [f {:row (r/get-line-number reader)
+           :col (r/get-column-number reader)
+           :message (apply format fmt data)}]
+    (throw (ex-info "Syntax error" {:findings [f]}))))
 
 (defn read-eol
   [reader]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1352,29 +1352,24 @@
 
 ;;;; processing of string input
 
-(defn- ->finding
-  "Convert an exception thrown from rewrite-clj into a clj-kondo :finding."
-  [^Exception e ^String filename]
-  (let [m (.getMessage e)]
-    (if-let [[_ msg row col]
-             (and m
-                  (re-find #"(.*)\[at line (\d+), column (\d+)\]"
-                           m))]
-      {:level :error
-       :filename filename
-       :col (Integer/parseInt col)
-       :row (Integer/parseInt row)
-       :type :syntax
-       :message (str/trim msg)}
-      {:level :error
-       :filename filename
-       :col 0
-       :row 0
-       :type :syntax
-       :message (str "can't parse "
-                     filename ", "
-                     (or m (str e)))})))
-
+(defn- ->findings
+  "Convert an exception thrown from rewrite-clj into a sequence clj-kondo :finding"
+  [^Exception ex ^String filename]
+  (if-let [findings (:findings (ex-data ex))]
+    (for [finding findings]
+      (merge {:type :syntax
+              :level :error
+              :filename filename}
+             finding))
+    [{:level :error
+      :filename filename
+      :col 0
+      :row 0
+      :type :syntax
+      :message (str "can't parse "
+                    filename ", "
+                    (or (.getMessage ex) (str ex)))}]))
+  
 (defn analyze-input
   "Analyzes input and returns analyzed defs, calls. Also invokes some
   linters and returns their findings."
@@ -1397,7 +1392,7 @@
       analyzed-expressions)
     (catch Exception e
       (if dev? (throw e)
-          {:findings [(->finding e filename)]}))
+          {:findings (->findings e filename)}))
     (finally
       (let [output-cfg (:output config)]
         (when (and (= :text (:format output-cfg))

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -40,24 +40,56 @@
     '[str-foo str-bar] "{:strs [str-foo str-bar]}"
     '[sym-foo sym-bar] "{:syms [sym-foo sym-bar]}"))
 
-
-(deftest ->finding-test
+(deftest ->findings-test
   (testing "unexpected exceptions"
-    (is (= {:level :error
-            :filename "file.clj"
-            :col 0
-            :row 0
-            :type :syntax
-            :message "can't parse file.clj, this is unexpected"}
-           (#'ana/->finding (Exception. "this is unexpected") "file.clj")))
+    (is (= [{:level :error
+             :filename "file.clj"
+             :col 0
+             :row 0
+             :type :syntax
+             :message "can't parse file.clj, this is unexpected"}]
+           (#'ana/->findings (Exception. "this is unexpected") "file.clj")))
     (testing "parse errors"
-      (is (= {:level :error
-              :filename "core.clj"
-              :col 9
-              :row 7
-              :type :syntax
-              :message "expected failure"}
-             (#'ana/->finding (Exception. "expected failure [at line 7, column 9]") "core.clj"))))))
+      (is (= [{:level :error
+               :filename "core.clj"
+               :col 0
+               :row 0
+               :type :syntax
+               :message "can't parse core.clj, expected failure"}]
+             (#'ana/->findings (ex-info "expected failure" {:row 7
+                                                            :col 9
+                                                            :type :syntax})
+                               "core.clj"))))))
+
+(deftest analyze-input-test
+  (let [analyze (fn [^String source]
+                  (ana/analyze-input {:config nil} "test.clj" source :clj false))]
+    (testing "unmatched delimiters"
+      (is (= {:findings [{:type :syntax
+                          :level :error
+                          :filename "test.clj"
+                          :row 1
+                          :col 1
+                          :message "Mismatched bracket: found an opening ( and a closing } on line 1"}
+                         {:type :syntax
+                          :level :error
+                          :filename "test.clj"
+                          :row 1
+                          :col 2
+                          :message "Mismatched bracket: found an opening ( on line 1 and a closing }"}]}
+             (analyze "(}"))))
+    (testing "unclosed delimiter"
+      (is (= {:findings [{:type :syntax
+                          :level :error
+                          :filename "test.clj"
+                          :row 1
+                          :col 1
+                          :message "Found an opening ( with no matching )"}
+                         {:type :syntax, :level :error, :filename "test.clj"
+                          :row 1
+                          :col 9
+                          :message "Expected a ) to match ( from line 1"}]}
+             (analyze "(defn []"))))))
 
 (comment
   (t/run-tests)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -233,10 +233,15 @@
   (testing "when an error happens in one file, the other file is still linted"
     (let [linted (lint! (io/file "corpus" "read_error"))]
       (is (= '({:file "corpus/read_error/error.clj",
+                :row 1,
+                :col 1,
+                :level :error,
+                :message "Found an opening ( with no matching )"}
+               {:file "corpus/read_error/error.clj"
                 :row 2,
                 :col 1,
                 :level :error,
-                :message "Unexpected EOF."}
+                :message "Expected a ) to match ( from line 1"}
                {:file "corpus/read_error/ok.clj",
                 :row 6,
                 :col 1,


### PR DESCRIPTION
Fixes #514

The error messages from the vendored copy of rewrite-clj are not as
helpful as they could be. I often have a hard time finding the location
of a mismatched bracket, since the error message refers to the EOF at
the end of the file, and not the opening paren.

To fix this we allow rewrite-clj to throw exceptions containing a
sequence of errors.

Changes:

- Make rewrite-clj throw ex-info instead of Exception. The ex-data
contains a :findings key, which is a sequence of findings in the format
expected by clj-kondo

- Change rewrite-clj.parser.core/*delimiters* to keep track of a tuple
of [open, close, row, col] rather than just the expected closing
delimiter. The extra three fields allow is to construct more informative
error messages when a parse error occurs.

- If an EOF is encountered when parsing a delimited list {}, [] or (),
throw an exception with two error messages - one for the opening
delimiter, saying that it is unmatched, and one for the end of file
saying that a closing delimiter was expected.

- If a mismatched delimiter is found when parsing a list ({}, [], ())
then throw two error messages - one for the opening bracket and one for
the closing bracket. In both cases, refer to both the line on which the
token is found, and the line on which the corresponding token is found.

Before:

> Unexpected EOF

After:

> Found an opening [ with no matching ]
> Expected a ] to match [ from line 1

Before:

> Unmatched delimiter: }

After:

> Mismatched bracket: found an opening [ and a closing } on line 1
> Mismatched bracket: found an opening [ on line 1 and a closing }