### PR TITLE
EOF reporting off by one error

### DIFF
--- a/test/clj_kondo/impl/parser_test.clj
+++ b/test/clj_kondo/impl/parser_test.clj
@@ -37,6 +37,7 @@
   ;; the `clj-kondo.impl.rewrite-clj.parser.utils/throw-reader` function.
   ;; This allows us to test for regressions when that function is refactored.
   (are [source message] (= message (parse-error source))
+    "[\n" "Unexpected EOF. [at line 1, column 2]"
     "[" "Unexpected EOF. [at line 1, column 2]"
     "[}" "Unmatched delimiter: } [at line 1, column 2]"
     "#" "Unexpected EOF. [at line 1, column 2]"


### PR DESCRIPTION
Expose a bug when reporting a premature EOF. It looks like the parser
skips whitespace greedily and throws the error at the wrong place.