### PR TITLE
Use an indexing reader when parsing EDN

### DIFF
--- a/inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader/edn.clj
+++ b/inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader/edn.clj
@@ -9,7 +9,7 @@
 (ns ^{:no-doc true} clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader.edn
   (:refer-clojure :exclude [read read-string char default-data-readers])
   (:require [clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader.reader-types :refer
-             [read-char unread peek-char indexing-reader?
+             [read-char unread peek-char indexing-reader? indexing-push-back-reader
               get-line-number get-column-number get-file-name string-push-back-reader]]
             [clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader.impl.utils :refer
              [char ex-info? whitespace? numeric? desugar-meta namespace-keys second']]
@@ -436,4 +436,5 @@
   ([s] (read-string {:eof nil} s))
   ([opts s]
      (when (and s (not (identical? s "")))
-       (read opts (string-push-back-reader s)))))
+       (read opts (indexing-push-back-reader
+                   (string-push-back-reader s))))))

--- a/inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader/impl/errors.clj
+++ b/inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader/impl/errors.clj
@@ -22,16 +22,8 @@
       details)))
 
 (defn ^:private throw-ex
-  [rdr ex-type  & msg]
-  (let [details (location-details rdr ex-type)
-        file (:file details)
-        line (:line details)
-        col (:col details)
-        msg1 (if file (str file " "))
-        msg2 (if line (str "[line " line ", col " col "]"))
-        msg3 (if (or msg1 msg2) " ")
-        full-msg (apply str msg1 msg2 msg3 msg)]
-    (throw (ex-info full-msg details))))
+  [rdr ex-type msg]
+    (throw (ex-info msg (location-details rdr ex-type))))
 
 (defn reader-error
   "Throws an ExceptionInfo with the given message.

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -89,7 +89,16 @@
                           :row 1
                           :col 9
                           :message "Expected a ) to match ( from line 1"}]}
-             (analyze "(defn []"))))))
+             (analyze "(defn []"))))
+
+    (testing "invalid tokens"
+      (is (= {:findings [{:type :syntax
+                          :level :error
+                          :filename "test.clj"
+                          :row 1
+                          :col 4
+                          :message "Invalid number: 1..1."}]}
+           (analyze "1..1"))))))
 
 (comment
   (t/run-tests)

--- a/test/clj_kondo/impl/parser_test.clj
+++ b/test/clj_kondo/impl/parser_test.clj
@@ -31,10 +31,11 @@
     (parse-string source)
     nil
     (catch Exception e
-      (if-let [findings (:findings (ex-data e))]
-        (for [{:keys [row col message]} findings]
-          [message row col])
-        [[(.getMessage e) 0 0]]))))
+      (let [{:keys [findings line col]} (ex-data e)]
+        (if findings
+          (for [{:keys [row col message]} findings]
+            [message row col])
+          [[(.getMessage e) line col]])))))
 
 (deftest parse-string-test
   ;; This test has every syntax error that can cause rewrite-clj to throw using
@@ -50,7 +51,7 @@
     ":"  [["unexpected EOF while reading keyword." 1 2]]
     "\"" [["Unexpected EOF while reading string." 1 2]]
     "#?" [[":reader-macro node expects 1 value." 1 3]]
-    "[1..1]" [["Invalid number: 1..1." 0 0]]
+    "[1..1]" [["Invalid number: 1..1." 1 4]]
     "#:" [["Unexpected EOF." 1 3]]))
 
 ;;;; Scratch


### PR DESCRIPTION
By passing an indexing reader to the edn parser, line and column
information is produced in the error messages.

    clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader.impl.errors/throw-ex

Remove the string formatting here. All of the data required by
->findings is contained in the ex-data. If we don't remove this string
formatting, then the error message shown to the user will be prepended
with `[line x, col y] `.

    clj-kondo.impl.analyzer/->findings

Now that tools.reader is throwing data, we need to update `->findings`
to be able to read that data correctly.

Add unit test to ensure that line data comes out of the parser, and an
integration to ensure that `->findings` works.