### PR TITLE
[#533] macroexpand (Obj.) to (new Obj)

### DIFF
--- a/corpus/cljs_ns_as_as_object.cljs
+++ b/corpus/cljs_ns_as_as_object.cljs
@@ -1,5 +1,7 @@
 (ns foo
   (:require [reagent.core :as r]
-            ["apsl-react-native-button" :as NativeButton]))
+            ["apsl-react-native-button" :as NativeButton]
+            ["constructor-export" :as ConstructorExport]))
 
 (def button (r/adapt-react-class NativeButton))
+(def obj (ConstructorExport.))

--- a/src/clj_kondo/impl/macroexpand.clj
+++ b/src/clj_kondo/impl/macroexpand.clj
@@ -143,6 +143,20 @@
                     let-expr fn-body)])
       m)))
 
+(defn expand-constructor
+  "Expand (Obj.) to (new Obj)."
+  [{:keys [children] :as expr}]
+  (let [ctor (-> children first :value)
+        ctor-name (name ctor)]
+    (if (= \. (last ctor-name))
+      (list-node
+       (list* (token-node 'new)
+              (token-node (-> ctor-name
+                              (subs 0 (dec (count ctor-name)))
+                              symbol))
+              (rest children)))
+      expr)))
+
 ;;;; Scratch
 
 (comment

--- a/src/clj_kondo/impl/macroexpand.clj
+++ b/src/clj_kondo/impl/macroexpand.clj
@@ -144,23 +144,6 @@
                     let-expr fn-body)])
       m)))
 
-#_(defn expand-constructor
-  "Expand (Obj.) to (new Obj)."
-  [expr]
-  (let [[ctor-node & children] (:children expr)
-        ctor (:value ctor-node)
-        ctor-name (name ctor)]
-    (if (str/ends-with? ctor-name ".")
-      (with-meta (list-node
-                  (list* (token-node 'new)
-                         (with-meta (token-node (-> ctor-name
-                                                    (subs 0 (dec (count ctor-name)))
-                                                    symbol))
-                           (meta ctor-node))
-                         (rest children)))
-        (meta expr))
-      expr)))
-
 ;;;; Scratch
 
 (comment

--- a/src/clj_kondo/impl/macroexpand.clj
+++ b/src/clj_kondo/impl/macroexpand.clj
@@ -3,8 +3,7 @@
   (:require
    [clj-kondo.impl.utils :refer [parse-string tag vector-node list-node
                                  token-node]]
-   [clj-kondo.impl.profiler :as profiler]
-   [clojure.string :as str]))
+   [clj-kondo.impl.profiler :as profiler]))
 
 (defn expand-> [_ctx expr]
   (profiler/profile
@@ -85,6 +84,18 @@
                                  (list-node [f gx])))
                              (meta f))) forms)))]
     ret))
+
+(defn expand-dot-constructor
+  [_ctx expr]
+  (let [[ctor-node & children] (:children expr)
+        ctor (:value ctor-node)
+        ctor-name (name ctor)
+        ctor-name (-> ctor-name
+                      (subs 0 (dec (count ctor-name)))
+                      symbol)
+        ctor-node (with-meta (token-node ctor-name)
+                    (meta ctor-node))]
+    (list-node (list* (token-node 'new) ctor-node children))))
 
 (defn find-children
   "Recursively filters children by pred"

--- a/src/clj_kondo/impl/macroexpand.clj
+++ b/src/clj_kondo/impl/macroexpand.clj
@@ -144,7 +144,7 @@
                     let-expr fn-body)])
       m)))
 
-(defn expand-constructor
+#_(defn expand-constructor
   "Expand (Obj.) to (new Obj)."
   [expr]
   (let [[ctor-node & children] (:children expr)

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -152,10 +152,7 @@
                 (config/unresolved-symbol-excluded config
                                                    callstack symbol)
                 (let [symbol-name (name symbol)]
-                  (or (str/starts-with? symbol-name
-                                        ".")
-                      (str/ends-with? symbol-name
-                                      ".")
+                  (or (str/starts-with? symbol-name ".")
                       (java-class? symbol-name))))
     (swap! namespaces update-in [base-lang lang ns-sym :unresolved-symbols symbol]
            (fn [old-sym-info]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1964,6 +1964,11 @@
                      {:linters {:unresolved-symbol {:level :error}}})))
   (is (empty? (lint! "(ns repro (:require [clojure.string :refer [starts-with?]]))
                       (defn foo {:test-fn starts-with?} [])"
+                     {:linters {:unresolved-symbol {:level :error}}})))
+  ;; There actually still is issue #450 that would cause this error. But we had
+  ;; special handling for constructor calls before and we don't want new errors
+  ;; when PR #557 is merged.
+  (is (empty? (lint! "(import my.ns.Obj) (Obj.)"
                      {:linters {:unresolved-symbol {:level :error}}}))))
 
 (deftest deftest-test


### PR DESCRIPTION
This fixes the issue #533 with CLJS when module export is a constructor that
is called in the short-hand constructor notation. It might also be
useful later for analyzing Java interop.

---

Rationale: just hacking special logic when cljs calls a function with a dot in the end didn't feel right, when Clojure always expands these calls to `new`.

However, this breaks tests at the moment. I'll fix them but just wanted to submit this code for comments.