### PR TITLE
Add additional :lang descriptions to analysis doc

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -20,6 +20,8 @@ The analysis output consists of a map with:
   - `:name`: the name of the namespace
 
   Optional:
+  - `:lang`: if definition occurred in a `.cljc` file, the language in which the
+    definition was done: `:clj` or `:cljs`
   - several metadata values: `:deprecated`, `:doc`, `:author`, `:added`, `:no-doc` (used by
     [codox](https://github.com/weavejester/codox)).
 
@@ -28,6 +30,10 @@ The analysis output consists of a map with:
    - `:from`: the namespace which uses
    - `:to`: the used namespace
    - `:alias`: the alias of namespace, if used
+
+   Optional
+   - `:lang`: if usage occurred in a `.cljc` file, the language in which it
+     was resolved: `:clj` or `:cljs`
 
 - `:var-definitions`, a list of maps with:
   - `:filename`, `:row`, `:col`


### PR DESCRIPTION
The analysis doc mentions :lang for :var-definitions and :var-usages, but not for :namespaces-definitions and :namespaces-usages.  This is an attempt to fill that info in a bit.