### PR TITLE
Make develop vs master spacemacs install more obvious

### DIFF
--- a/doc/editor-integration.md
+++ b/doc/editor-integration.md
@@ -148,6 +148,8 @@ Ensure that:
 
 In the `.spacemacs` file:
 
+### Installing on master branch
+
 When using the stable `master` branch:
 
 1. In `dotspacemacs-additional-packages` add `flycheck-clj-kondo`.
@@ -179,6 +181,8 @@ To install it alongside joker:
                         (clj-kondo-edn . edn-joker)))
       (flycheck-add-next-checker (car checkers) (cons 'error (cdr checkers)))))
    ```
+
+### Installing on develop branch
 
 If using the `develop` branch, clj-kondo is available as a part of the standard
 clojure layer. This will become the way to install in the next stable


### PR DESCRIPTION
Currently it's easy to miss that there's a difference in how you install this on `master` vs `develop` `spacemacs` branches.

Or mainly because I installed this on `master` first and then upgraded to `develop` and was wondering why it wasn't working 😅 