### PR TITLE
Adds example for when lint-as clojure.core/-> does not work

### DIFF
--- a/corpus/lint_as__GT.clj
+++ b/corpus/lint_as__GT.clj
@@ -1,0 +1,12 @@
+(ns lint-as--GT
+  {:clj-kondo/config {:lint-as {lint-as--GT/injecting-thread-first clojure.core/->}}})
+
+(defmacro injecting-thread-first
+  [& body]
+  `(-> :inject ~@body))
+
+(defn arity-2 [x y]
+  [x y])
+
+(injecting-thread-first (arity-2 :y)
+                        (arity-2 :foo))


### PR DESCRIPTION
Failing example for lint-as clojure.core/->

    $ clj -A:clj-kondo --lint corpus/lint_as__GT.clj
    corpus/lint_as__GT.clj:11:25: error: lint-as--GT/arity-2 is called with 1 arg but expects 2
    corpus/lint_as__GT.clj:12:25: error: lint-as--GT/arity-2 is called with 1 arg but expects 2
    linting took 111ms, errors: 2, warnings: 0