### PR TITLE
Only complain about inconsistent ns alias when an alias is defined

### DIFF
--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -65,7 +65,7 @@
 (defn lint-alias-consistency [{:keys [:findings :config
                                       :filename]} ns-name alias]
   (when-let [expected-alias (get-in config [:linters :consistent-alias :aliases ns-name])]
-    (when-not (= expected-alias alias)
+    (when (and alias (not= expected-alias alias))
       (findings/reg-finding!
        findings
        (node->line filename alias :warning

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -65,7 +65,7 @@
 (defn lint-alias-consistency [{:keys [:findings :config
                                       :filename]} ns-name alias]
   (when-let [expected-alias (get-in config [:linters :consistent-alias :aliases ns-name])]
-    (when (and alias (not= expected-alias alias))
+    (when-not (= expected-alias alias)
       (findings/reg-finding!
        findings
        (node->line filename alias :warning
@@ -164,7 +164,7 @@
                 (recur (nnext children)
                        m)))
             (let [{:keys [:as :referred :excluded :referred-all :renamed]} m]
-              (lint-alias-consistency ctx ns-name as)
+              (when as (lint-alias-consistency ctx ns-name as))
               [{:type :require
                 :ns ns-name
                 :as as

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2336,10 +2336,12 @@
 
 (deftest consistent-alias-test
   (assert-submaps
-   [{:file "<stdin>", :row 1, :col 39,
-     :level :warning, :message #"Inconsistent.*str.*x"}]
-   (lint! "(ns foo (:require [clojure.string :as x])) x/join"
-          {:linters {:consistent-alias {:aliases '{clojure.string str}}}})))
+    [{:file "<stdin>", :row 1, :col 39,
+      :level :warning, :message #"Inconsistent.*str.*x"}]
+    (lint! "(ns foo (:require [clojure.string :as x])) x/join"
+           {:linters {:consistent-alias {:aliases '{clojure.string str}}}}))
+  (is (empty? (lint! "(ns foo (:require [clojure.string])) x/join"
+                     {:linters {:consistent-alias {:aliases '{clojure.string str}}}}))))
 
 (deftest set!-test
   (assert-submaps '[{:col 13 :message #"arg"}]


### PR DESCRIPTION
We should only complain about inconsistent ns aliases when the alias is actually present.

Fixes #650 