### PR TITLE
Fix some type specs for clojure.core associative functions

### DIFF
--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -321,11 +321,7 @@
                       :ret :vector}}}
    ;; 1478 'map-entry?
    ;; 1484 'contains?
-   ;; 1494
-   'get {:arities {2 {:args [:nilable/associative :any]
-                      :ret :any}
-                   3 {:args [:nilable/associative :any :any]
-                      :ret :any}}}
+   ;; 1494 'get
    ;; 1504
    'dissoc {:arities {:varargs {:args [:nilable/map {:op :rest :spec :any}]
                                 :ret :nilable/map}}}

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -321,7 +321,11 @@
                       :ret :vector}}}
    ;; 1478 'map-entry?
    ;; 1484 'contains?
-   ;; 1494 'get
+   ;; 1494
+   'get {:arities {2 {:args [:nilable/associative :any]
+                      :ret :any}
+                   3 {:args [:nilable/associative :any :any]
+                      :ret :any}}}
    ;; 1504
    'dissoc {:arities {:varargs {:args [:nilable/map {:op :rest :spec :any}]
                                 :ret :nilable/map}}}

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -321,7 +321,7 @@
                       :ret :vector}}}
    ;; 1478 'map-entry?
    ;; 1484 'contains?
-   ;; NOTE: get is an any->any function on any object that implements ILookup
+   ;; NOTE: get is an any->any function on any object that implements ILookup.
    ;; 1494 'get
    ;; 1504
    'dissoc {:arities {:varargs {:args [:nilable/map {:op :rest :spec :any}]

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -323,13 +323,13 @@
    ;; 1484 'contains?
    ;; 1494 'get
    ;; 1504
-   'dissoc {:arities {:varargs {:args [:map {:op :rest :spec :any}]
-                                :ret :map}}}
+   'dissoc {:arities {:varargs {:args [:nilable/map {:op :rest :spec :any}]
+                                :ret :nilable/map}}}
    ;; 1518 'disj
    ;; 1534
-   'find {:arities {2 {:args [:associative :any]}}}
+   'find {:arities {2 {:args [:nilable/associative :any]}}}
    ;; 1540
-   'select-keys {:arities {2 {:args [:associative :seqable]
+   'select-keys {:arities {2 {:args [:nilable/associative :seqable]
                               :ret :map}}}
    ;; 1555
    'keys {:arities {1 {:args [:nilable/associative]

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -321,6 +321,7 @@
                       :ret :vector}}}
    ;; 1478 'map-entry?
    ;; 1484 'contains?
+   ;; NOTE: get is an any->any function on any object that implements ILookup
    ;; 1494 'get
    ;; 1504
    'dissoc {:arities {:varargs {:args [:nilable/map {:op :rest :spec :any}]
@@ -332,6 +333,7 @@
    'select-keys {:arities {2 {:args [:nilable/associative :seqable]
                               :ret :map}}}
    ;; 1555
+   ;; NOTE: keys and vals can be called on seqs of MapEntry's, hence not :associative.
    'keys {:arities {1 {:args [:seqable]
                        :ret :seqable}}}
    ;; 1561

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -336,10 +336,10 @@
    'select-keys {:arities {2 {:args [:nilable/associative :seqable]
                               :ret :map}}}
    ;; 1555
-   'keys {:arities {1 {:args [:nilable/associative]
+   'keys {:arities {1 {:args [:seqable]
                        :ret :seqable}}}
    ;; 1561
-   'vals {:arities {1 {:args [:nilable/associative]
+   'vals {:arities {1 {:args [:seqable]
                        :ret :seqable}}}
    ;; 1567 'key
    ;; 1574 'val

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -332,10 +332,10 @@
    'select-keys {:arities {2 {:args [:associative :seqable]
                               :ret :map}}}
    ;; 1555
-   'keys {:arities {1 {:args [:seqable]
+   'keys {:arities {1 {:args [:nilable/associative]
                        :ret :seqable}}}
    ;; 1561
-   'vals {:arities {1 {:args [:seqable]
+   'vals {:arities {1 {:args [:nilable/associative]
                        :ret :seqable}}}
    ;; 1567 'key
    ;; 1574 'val

--- a/test/clj_kondo/types_test.clj
+++ b/test/clj_kondo/types_test.clj
@@ -437,7 +437,9 @@
                        {:linters {:type-mismatch {:level :error}}}))))
   (testing "collection could be a function"
     (is (empty? (lint! "(filter (conj #{} 1) [1])"
-                       {:linters {:type-mismatch {:level :error}}})))))
+                       {:linters {:type-mismatch {:level :error}}}))))
+  (testing "nilable types"
+    (is (empty? (lint! "(dissoc nil) (dissoc nil 1 2 3) (find nil 1) (select-keys nil [1 2 3])")))))
 
 ;;;; Scratch
 


### PR DESCRIPTION
As discussed in the Slack channel, this PR corrects the argument types for some clojure.core functions from `:associative` -> `:nilable/associative`.

Also adds spec for `get` and fixes wrong type signatures of `keys` and `vals`.