### PR TITLE
Changes to seq-returning functions

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -163,9 +163,7 @@
                      tags (map :tag (map meta v))
                      expr-meta (meta expr)
                      t (:tag expr-meta)
-                     t (when t (types/tag-from-meta t true ;; true means it's a
-                                                    ;; return type
-                                                    ))]
+                     t (when t (types/tag-from-meta t))]
                  (with-meta (into {} v)
                    ;; this is used for checking the return tag of a function body
                    (assoc expr-meta

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -24,7 +24,7 @@
    :nat-int #{:int :number}
    :neg-int #{:int :number}
    :double #{:number}
-   :vector #{:seqable :seqable-out :sequential :associative :coll :ifn}
+   :vector #{:seqable :seqable-out :sequential :associative :coll :ifn :stack}
    :map #{:seqable :associative :coll :ifn}
    :nil #{:seqable}
    :seqable-out #{:sequential :seqable :coll}
@@ -35,7 +35,7 @@
    :symbol #{:ifn}
    :associative #{:seqable :coll :ifn}
    :transducer #{:ifn}
-   :list #{:seq :sequential :seqable :seqable-out :coll}
+   :list #{:seq :sequential :seqable :seqable-out :coll :stack}
    :seq #{:seqable :seqable-out :sequential :coll}
    :sequential #{:coll :seqable}})
 
@@ -47,15 +47,17 @@
    :coll #{:map :vector :set :list :seqable-out :associative :seq :sequential :ifn}
    :seqable #{:coll :vector :set :map :associative
               :char-sequence :string :nil :seqable-out
-              :list :seq :sequential :ifn}
+              :list :seq :sequential :ifn :stack}
    :associative #{:map :vector :sequential}
    :ifn #{:fn :transducer :symbol :keyword :map :set :vector :associative :seqable :coll
-          :sequential}
+          :sequential :stack}
    :nat-int #{:pos-int}
-   :seq #{:list}
-   :sequential #{:seq :list :vector :seqable-out :ifn :associative}})
+   :seq #{:list :stack}
+   :stack #{:list :vector}
+   :sequential #{:seq :list :vector :seqable-out :ifn :associative :stack}})
 
 (def misc-types #{:boolean :atom :regex :char})
+
 
 (defn nilable? [k]
   (= "nilable" (namespace k)))
@@ -80,6 +82,7 @@
    :seqable "seqable collection"
    :seq "seq"
    :vector "vector"
+   :stack "stack (list, vector, etc.)"
    :associative "associative collection"
    :map "map"
    :coll "collection"

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -44,7 +44,7 @@
    :int #{:neg-int :nat-int :pos-int}
    :number #{:neg-int :pos-int :nat-int :int :double}
    :seqable-out #{:list :vector :seq}
-   :coll #{:map :vector :set :list :seqable-out :associative :seq :sequential :ifn}
+   :coll #{:map :vector :set :list :seqable-out :associative :seq :sequential :ifn :stack}
    :seqable #{:coll :vector :set :map :associative
               :char-sequence :string :nil :seqable-out
               :list :seq :sequential :ifn :stack}
@@ -53,7 +53,7 @@
           :sequential :stack}
    :nat-int #{:pos-int}
    :seq #{:list :stack}
-   :stack #{:list :vector}
+   :stack #{:list :vector :seq :sequential :seqable :seqable-out :coll :ifn :associative}
    :sequential #{:seq :list :vector :seqable-out :ifn :associative :stack}})
 
 (def misc-types #{:boolean :atom :regex :char})

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -48,7 +48,7 @@
    :seqable #{:coll :vector :set :map :associative
               :char-sequence :string :nil :seqable-out
               :list :seq :sequential :ifn :stack}
-   :associative #{:map :vector :sequential}
+   :associative #{:map :vector :sequential :stack}
    :ifn #{:fn :transducer :symbol :keyword :map :set :vector :associative :seqable :coll
           :sequential :stack}
    :nat-int #{:pos-int}

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -138,28 +138,27 @@
 ;; TODO: we could look more intelligently at the source of the tag, e.g. if it
 ;; is not a third party String type
 (defn tag-from-meta
-  ([meta-tag] (tag-from-meta meta-tag false))
-  ([meta-tag out?]
-   (case meta-tag
-     void :nil
-     (boolean) :boolean
-     (Boolean java.lang.Boolean) :nilable/boolean
-     (byte) :byte
-     (Byte java.lang.Byte) :nilable/byte
-     (Number java.lang.Number) :nilable/number
-     (int long) :int
-     (Long java.lang.Long) :nilable/int #_(if out? :any-nilable-int :any-nilable-int) ;; or :any-nilable-int? , see 2451 main-test
-     (float double) :double
-     (Float Double java.lang.Float java.lang.Double) :nilable/double
-     (CharSequence java.lang.CharSequence) :nilable/char-sequence
-     (String java.lang.String) :nilable/string ;; as this is now way to
-     ;; express non-nilable,
-     ;; we'll go for the most
-     ;; relaxed type
-     (char) :char
-     (Character java.lang.Character) :nilable/char
-     (Seqable clojure.lang.Seqable) :seqable
-     (do #_(prn "did not catch tag:" meta-tag) nil nil))))
+  [meta-tag]
+  (case meta-tag
+    void :nil
+    (boolean) :boolean
+    (Boolean java.lang.Boolean) :nilable/boolean
+    (byte) :byte
+    (Byte java.lang.Byte) :nilable/byte
+    (Number java.lang.Number) :nilable/number
+    (int long) :int
+    (Long java.lang.Long) :nilable/int #_(if out? :any-nilable-int :any-nilable-int) ;; or :any-nilable-int? , see 2451 main-test
+    (float double) :double
+    (Float Double java.lang.Float java.lang.Double) :nilable/double
+    (CharSequence java.lang.CharSequence) :nilable/char-sequence
+    (String java.lang.String) :nilable/string ;; as this is now way to
+    ;; express non-nilable,
+    ;; we'll go for the most
+    ;; relaxed type
+    (char) :char
+    (Character java.lang.Character) :nilable/char
+    (Seqable clojure.lang.Seqable) :seqable
+    (do #_(prn "did not catch tag:" meta-tag) nil nil)))
 
 (defn number->tag [v]
   (cond (int? v)

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -24,10 +24,9 @@
    :nat-int #{:int :number}
    :neg-int #{:int :number}
    :double #{:number}
-   :vector #{:seqable :seqable-out :sequential :associative :coll :ifn :stack}
+   :vector #{:seqable :sequential :associative :coll :ifn :stack}
    :map #{:seqable :associative :coll :ifn}
    :nil #{:seqable}
-   :seqable-out #{:sequential :seqable :coll}
    :coll #{:seqable}
    :set #{:seqable :coll :ifn}
    :fn #{:ifn}
@@ -35,26 +34,25 @@
    :symbol #{:ifn}
    :associative #{:seqable :coll :ifn}
    :transducer #{:ifn}
-   :list #{:seq :sequential :seqable :seqable-out :coll :stack}
-   :seq #{:seqable :seqable-out :sequential :coll}
+   :list #{:seq :sequential :seqable :coll :stack}
+   :seq #{:seqable :sequential :coll}
    :sequential #{:coll :seqable}})
 
 (def could-be-relations
   {:char-sequence #{:string}
    :int #{:neg-int :nat-int :pos-int}
    :number #{:neg-int :pos-int :nat-int :int :double}
-   :seqable-out #{:list :vector :seq}
-   :coll #{:map :vector :set :list :seqable-out :associative :seq :sequential :ifn :stack}
+   :coll #{:map :vector :set :list  :associative :seq :sequential :ifn :stack}
    :seqable #{:coll :vector :set :map :associative
-              :char-sequence :string :nil :seqable-out
+              :char-sequence :string :nil
               :list :seq :sequential :ifn :stack}
    :associative #{:map :vector :sequential :stack}
    :ifn #{:fn :transducer :symbol :keyword :map :set :vector :associative :seqable :coll
           :sequential :stack}
    :nat-int #{:pos-int}
    :seq #{:list :stack}
-   :stack #{:list :vector :seq :sequential :seqable :seqable-out :coll :ifn :associative}
-   :sequential #{:seq :list :vector :seqable-out :ifn :associative :stack}})
+   :stack #{:list :vector :seq :sequential :seqable :coll :ifn :associative}
+   :sequential #{:seq :list :vector :ifn :associative :stack}})
 
 (def misc-types #{:boolean :atom :regex :char})
 
@@ -78,7 +76,6 @@
    :pos-int "positive integer"
    :nat-int "natural integer"
    :neg-int "negative integer"
-   :seqable-out "seqable collection"
    :seqable "seqable collection"
    :seq "seq"
    :vector "vector"
@@ -161,7 +158,7 @@
      ;; relaxed type
      (char) :char
      (Character java.lang.Character) :nilable/char
-     (Seqable clojure.lang.Seqable) (if out? :seqable-out :seqable)
+     (Seqable clojure.lang.Seqable) :seqable
      (do #_(prn "did not catch tag:" meta-tag) nil nil))))
 
 (defn number->tag [v]

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -314,11 +314,11 @@
    ;; 1451
    'identity a->a
    ;; 1459
-   'peek {:arities {1 {:args [:vector]
+   'peek {:arities {1 {:args [:stack]
                        :ret :any}}}
    ;; 1467
-   'pop {:arities {1 {:args [:vector]
-                      :ret :vector}}}
+   'pop {:arities {1 {:args [:stack]
+                      :ret :stack}}}
    ;; 1478 'map-entry?
    ;; 1484 'contains?
    ;; NOTE: get is an any->any function on any object that implements ILookup.

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -576,7 +576,11 @@
    ;; 3770 'read+string
    ;; 3796 'read-line
    ;; 3805 'read-string
-   ;; 3818 'subvec
+   ;; 3818
+   'subvec {:arities {2 {:args [:vector :nat-int]
+                         :ret :vector}
+                      3 {:args [:vector :nat-int :nat-int]
+                         :ret :vector}}}
    ;; 3831 'with-open
    ;; 3852 'doto
    ;; 3871 'memfn

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -7,8 +7,8 @@
 ;; a lot of this work was already figured out here:
 ;; https://github.com/borkdude/speculative/blob/master/src/speculative/core.cljc
 
-(def seqable->seqable {:arities {1 {:args [:seqable]
-                                    :ret :seqable-out}}})
+(def seqable->seq {:arities {1 {:args [:seqable]
+                                :ret :seq}}})
 
 (def seqable->any {:arities {1 {:args [:seqable]
                                 :ret :any}}})
@@ -53,9 +53,9 @@
    ;; 49
    'first seqable->any
    ;; 57
-   'next seqable->seqable
+   'next seqable->seq
    ;; 66
-   'rest seqable->seqable
+   'rest seqable->seq
    ;; 75
    'conj {:arities {0 {:args [:coll]
                        :ret :coll}
@@ -66,11 +66,11 @@
    ;; 98
    'ffirst seqable->any
    ;; 105
-   'nfirst seqable->seqable
+   'nfirst seqable->seq
    ;; 112
    'fnext seqable->any
    ;; 119
-   'nnext seqable->seqable
+   'nnext seqable->seq
    ;; 126
    'seq {:arities {1 {:args [:seqable]
                       :ret :seq}}}
@@ -102,7 +102,7 @@
    ;; 262
    'last seqable->any
    ;; 272
-   'butlast seqable->seqable
+   'butlast seqable->seq
    ;; 283 'defn
    ;; 338 'to-array
    ;; 346 'cast
@@ -209,7 +209,7 @@
    'inc number->number
    ;; 947
    'reverse {:arities {1 {:args [:seqable]}}
-             :ret :seqable-out}
+             :ret :seq}
    ;; 972
    '+' number*->number
    ;; 984
@@ -458,7 +458,7 @@
                       :ret :transducer}
                    :varargs {:args '[:ifn :seqable [{:op :rest
                                                      :spec :seqable}]]
-                             :ret :seqable-out}}}
+                             :ret :seq}}}
    ;; 2776 'declare
    ;; 2781 'cat
    ;; 2783 'mapcat
@@ -466,12 +466,12 @@
    'filter {:arities {1 {:args [:ifn]
                          :ret :transducer}
                       2 {:args [:ifn :seqable]
-                         :ret :seqable-out}}}
+                         :ret :seq}}}
    ;; 2826
    'remove {:arities {1 {:args [:ifn]
                          :ret :transducer}
                       2 {:args [:ifn :seqable]
-                         :ret :seqable-out}}}
+                         :ret :seq}}}
    ;; 2836 'reduced
    ;; 2842 'reduced?
    ;; 2849 'ensure-reduced
@@ -889,7 +889,7 @@
    'keep {:arities {1 {:args [:ifn]
                        :ret :transducer}
                     2 {:args [:ifn :seqable]
-                       :ret :seqable-out}}}
+                       :ret :seq}}}
    ;; 7283
    'keep-indexed {:arities {1 {:args [:ifn]
                                :ret :transducer}

--- a/test/clj_kondo/types_test.clj
+++ b/test/clj_kondo/types_test.clj
@@ -59,7 +59,7 @@
       :row 2,
       :col 28,
       :level :error,
-      :message "Expected: set or nil, received: seqable collection."}
+      :message "Expected: set or nil, received: seq."}
      {:file "<stdin>",
       :row 3,
       :col 28,
@@ -83,6 +83,23 @@
    (lint! "(require '[clojure.string :as str])
            (str/starts-with? 1 \"s\")
            (str/includes? (str/join [1 2 3]) 1)"
+          {:linters {:type-mismatch {:level :error}}}))
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 9,
+      :level :error,
+      :message "Expected: vector, received: seq."})
+   (lint! "(subvec (map inc [1 2 3]) 10 20)"
+          {:linters {:type-mismatch {:level :error}}}))
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 7,
+      :level :error,
+      :message
+      "Expected: stack (list, vector, etc.), received: set."})
+   (lint! "(peek #{:a :b :c})"
           {:linters {:type-mismatch {:level :error}}}))
   (testing "No type checking if invalid-arity is disabled"
     (assert-submaps


### PR DESCRIPTION
As per the discussion in #657, and open to changes/rejection.

I tried to add a :stack = #{:list :vector} type as suggested, but was forced to expand its scope so much due to the transitive requirements that it ended up being nearly useless.

Given that, perhaps `peek` and `pop` should be simply specced as `#{:list :vector}` instead of introducing a new type?