### PR TITLE
Don't specify current directory as cache

### DIFF
--- a/doc/editor-integration.md
+++ b/doc/editor-integration.md
@@ -145,25 +145,25 @@ This section assumes that you are already using
 
 1. Install the [File
 Watchers](https://www.jetbrains.com/help/idea/settings-tools-file-watchers.html)
-plugin.
+plugin
 
 Repeat the below steps for the file types Clojure (`.clj`), ClojureScript (`.cljs`)
 and CLJC (`.cljc`).
 
 2. Under Preferences / Tools / File Watchers click `+` and choose the `<custom>`
-   template.
+   template
 3. Choose a name. E.g. `clj-kondo <filetype>` (where `<filetype>` is one of
-   Clojure, ClojureScript or CLJC).
-4. In the File type field, choose the correct filetype.
+   Clojure, ClojureScript or CLJC)
+4. In the File type field, choose the correct filetype
 5. Scope: `Current file`
-6. In the Program field, type `clj-kondo`.
-7. In the Arguments field, type `--lint $FilePath$ --cache`.<br>
-You may use a custom config E.g `--lint $FilePath$ --cache --config "{:lint-as {manifold.deferred/let-flow clojure.core/let}}"`.
-8. In the Working directory field, type `$FileDir$`.
+6. In the Program field, type `clj-kondo`
+7. In the Arguments field, type `--lint $FilePath$`<br>
+You may use a custom config E.g `--lint $FilePath$ --config "{:lint-as {manifold.deferred/let-flow clojure.core/let}}"`.
+8. In the Working directory field, type `$FileDir$`
 9. Enable `Create output file from stdout`
 10. Show console: `Never`
-11. In output filters put `$FILE_PATH$:$LINE$:$COLUMN$: $MESSAGE$`.
-12. Click `ok` and under the newly created file-watcher, change level to `Global` - this will enable the watcher in all future projects.
+11. In output filters put `$FILE_PATH$:$LINE$:$COLUMN$: $MESSAGE$`
+12. Click `ok` and under the newly created file-watcher, change level to `Global` - this will enable the watcher in all future projects
 
 <img src="../screenshots/intellij-fw-config.png">
 


### PR DESCRIPTION
Following the current doc produces a lot of cache directories/files everywhere in the project, where/when the linter is executed. Also, this PR removes confusing `.` characters, we don't know if they should be part of the input or if they end the sentence. For consistency's sake it also removes all ending `.`. I only did it for Cursive as I noticed no other editor integration specified the `cache` option manually.