### PR TITLE
Add CI integration doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ directory, use `--cache false`.
 
 All other error codes indicate an unexpected error.
 
+## [CI Integration](doc/ci-integration.md)
 ## [Analysis data](analysis)
 
 ## [Developer documentation](doc/dev.md)

--- a/doc/ci-integration.md
+++ b/doc/ci-integration.md
@@ -1,0 +1,11 @@
+# CI integration
+
+After correctly setting up `clj-kondo`, you might want to leverage its powers during the test / build phase your project.
+
+## GitHub
+
+A number of [GitHub Actions](https://github.com/features/actions) that use `clj-kondo` are available:
+
+
+- [clojure-lint-action](https://github.com/marketplace/actions/clj-kondo-checks)
+- [lint-clojure](https://github.com/marketplace/actions/clj-kondo)


### PR DESCRIPTION
Add a new page named "CI integration" where we can collect all the useful info about connecting `clj-kondo` to the existing workflow of a project.