### PR TITLE
fixes parsing config from file path from cli. issue #719

### DIFF
--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -64,7 +64,7 @@
                        (str/starts-with? config "^"))
                    (edn/read-string config)
                    ;; config is a string that represents a file
-                   :else (read-edn-file config)))]))
+                   :else (read-edn-file (io/file config))))]))
 
 ;;;; process cache
 


### PR DESCRIPTION
fixes ClassCastException bc string is passed but `read-edn-file` has type hint for `java.io.File`