### PR TITLE
adds a test which passes a config as a file path. relevant to issue #719

### DIFF
--- a/corpus/config/invalid_arity.edn
+++ b/corpus/config/invalid_arity.edn
@@ -1,0 +1,2 @@
+{:linters {:invalid-arity {:level :off}
+           :unused-binding {:level :off}}}

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -62,7 +62,15 @@
       (assert-submaps
        [{:level :error, :type :unresolved-symbol, :message "unresolved symbol x",
          :row 1, :col 2, :end-row 1, :end-col 3}]
-       findings))))
+       findings)))
+  (testing "passing file as config arg"
+    (let [{{:keys [error warning info]} :summary}
+          (clj-kondo/run!
+            {:lint   [(file-path "corpus" "invalid_arity")]
+             :config (file-path "corpus" "config" "invalid_arity.edn")})]
+      (is (zero? error))
+      (is (zero? warning))
+      (is (zero? info)))))
 
 ;;;; Scratch
 


### PR DESCRIPTION
added a single simple test. without the config arg, there are 9 errors and 7 warnings, but with the config there are 0 for each. let me know if this works or if we should check some other cases