### PR TITLE
fix doc/jvm.md missing }

### DIFF
--- a/doc/jvm.md
+++ b/doc/jvm.md
@@ -10,7 +10,7 @@ You can add clj-kondo to `~/.lein/profiles.clj` to make it available as a `lein`
 
 ``` clojure
 {:user {:dependencies [[clj-kondo "RELEASE"]]
-        :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]}
+        :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]}}}
 ```
 
 ``` shellsession


### PR DESCRIPTION
There were two missing `}` in the documentation. no additional changes