### PR TITLE
[#260] Add linting for single arity comparison

### DIFF
--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -76,7 +76,7 @@
                                  ;; different from str
                                  :aliases {#_clojure.string #_str}}
               :unused-import {:level :warning}
-              :single-arity-comparison {:level :warning}}
+              :single-operand-comparison {:level :warning}}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>
               rewrite-clj.custom-zipper.core/defn-switchable clojure.core/defn

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -140,8 +140,8 @@
           (if (= 1 called-with) "arg" "args")
           (show-arities fixed-arities varargs-min-arity)))
 
-(defn lint-single-arity-comparison
-  "Lints calls of single arity comparisons with constant vlaue."
+(defn lint-single-operand-comparison
+  "Lints calls of single operand comparisons with always the same vlaue."
   [call]
   (let [ns-name (:resolved-ns call)
         core-ns (utils/one-of ns-name [clojure.core cljs.core])]
@@ -155,8 +155,8 @@
            (:filename call)
            (:expr call)
            :warning
-           :single-arity-comparison
-           (format "Single arity use of %s is always %s"
+           :single-operand-comparison
+           (format "Single operand use of %s is always %s"
                    (str ns-name "/" fn-name)
                    (some? const-true))))))))
 
@@ -266,10 +266,10 @@
                                   varargs-min-arity)
                               (not (or (contains? fixed-arities arity)
                                        (and varargs-min-arity (>= arity varargs-min-arity)))))
-                             single-arity-comparison-error
+                             single-operand-comparison-error
                              (and call?
-                                  (not (utils/linter-disabled? call :single-arity-comparison))
-                                  (lint-single-arity-comparison call))
+                                  (not (utils/linter-disabled? call :single-operand-comparison))
+                                  (lint-single-operand-comparison call))
                              errors
                              [(when arity-error?
                                 {:filename filename
@@ -279,8 +279,8 @@
                                  :end-col end-col
                                  :type :invalid-arity
                                  :message (arity-error fn-ns fn-name arity fixed-arities varargs-min-arity)})
-                              (when single-arity-comparison-error
-                                single-arity-comparison-error)
+                              (when single-operand-comparison-error
+                                single-operand-comparison-error)
                               (when (and (:private called-fn)
                                          (not= caller-ns-sym
                                                fn-ns)

--- a/test/clj_kondo/single_arity_comparison_test.clj
+++ b/test/clj_kondo/single_arity_comparison_test.clj
@@ -7,13 +7,13 @@
   (testing "test full linting error for single arity comparison in clojure"
     (assert-submaps
      '({:file "<stdin>", :row 1, :col 1, :level :warning,
-        :message "single arity use of clojure.core/= is constantly true"})
+        :message "Single arity use of clojure.core/= is always true"})
      (lint! "(= 1)")))
 
   (testing "test full linting error for single arity comparison in cljs"
     (assert-submaps
      '({:file "<stdin>", :row 1, :col 1, :level :warning,
-        :message "single arity use of cljs.core/not= is constantly false"})
+        :message "Single arity use of cljs.core/not= is always false"})
      (lint! "(not= 1)" "--lang" "cljs")))
 
   (testing "test linting comparison operators with single arity"
@@ -21,7 +21,7 @@
             op ["=" ">" "<" ">=" "<=" "=="]
             :let [errors (lint! (str "(" op " 1)") "--lang" lang)]]
       (is (= 1 (count errors)))
-      (is (= (format "single arity use of %s.core/%s is constantly true"
+      (is (= (format "Single arity use of %s.core/%s is always true"
                      (get {"clj" "clojure"} lang "cljs")
                      op)
              (-> errors

--- a/test/clj_kondo/single_operand_comparison_test.clj
+++ b/test/clj_kondo/single_operand_comparison_test.clj
@@ -1,39 +1,39 @@
-(ns clj-kondo.single-arity-comparison-test
+(ns clj-kondo.single-operand-comparison-test
   (:require
    [clj-kondo.test-utils :refer [lint! assert-submaps]]
    [clojure.test :as t :refer [deftest is testing]]))
 
-(deftest single-arity-comparison-test
-  (testing "test full linting error for single arity comparison in clojure"
+(deftest single-operand-comparison-test
+  (testing "test full linting error for single operand comparison in clojure"
     (assert-submaps
      '({:file "<stdin>", :row 1, :col 1, :level :warning,
-        :message "Single arity use of clojure.core/= is always true"})
+        :message "Single operand use of clojure.core/= is always true"})
      (lint! "(= 1)")))
 
-  (testing "test full linting error for single arity comparison in cljs"
+  (testing "test full linting error for single operand comparison in cljs"
     (assert-submaps
      '({:file "<stdin>", :row 1, :col 1, :level :warning,
-        :message "Single arity use of cljs.core/not= is always false"})
+        :message "Single operand use of cljs.core/not= is always false"})
      (lint! "(not= 1)" "--lang" "cljs")))
 
-  (testing "test linting comparison operators with single arity"
+  (testing "test linting comparison operators with single operand"
     (doseq [lang ["clj" "cljs"]
             op ["=" ">" "<" ">=" "<=" "=="]
             :let [errors (lint! (str "(" op " 1)") "--lang" lang)]]
       (is (= 1 (count errors)))
-      (is (= (format "Single arity use of %s.core/%s is always true"
+      (is (= (format "Single operand use of %s.core/%s is always true"
                      (get {"clj" "clojure"} lang "cljs")
                      op)
              (-> errors
                  (first)
                  :message)))))
 
-  (testing "test linting single arity comparison in threading macros"
+  (testing "test linting single operand comparison in threading macros"
     (is (seq (lint! "(-> 10 (>))")))
     (is (seq (lint! "(->> 10 (>))")))
     (is (seq (lint! "(def x 11)(->> x (+ 1) (>))"))))
 
-  (testing "test linting single arity comparison for valid expressions"
+  (testing "test linting single operand comparison for valid expressions"
     (doseq [expr ["(= 1 2)"
                   "(= (== 1 2) false)"
                   "(-> 10 (> 20))"


### PR DESCRIPTION
Request adds linting for calls of logical operators and comparators with single arity that always produce the same value.

Linting diff:
```bash
130d129
< cljs/analyzer.cljc:2869:10: warning: 1-arity use of cljs.core/or always evaluates to the same value
332,335d330
< cljs/core.cljs:1872:11: warning: 1-arity use of cljs.core/and always evaluates to the same value
< cljs/core.cljs:1877:11: warning: 1-arity use of cljs.core/and always evaluates to the same value
< cljs/core.cljs:1905:11: warning: 1-arity use of cljs.core/and always evaluates to the same value
< cljs/core.cljs:1910:11: warning: 1-arity use of cljs.core/and always evaluates to the same value
1922,1923c1917
< src/clj_kondo/impl/linters.clj:29:19: warning: 1-arity use of clojure.core/and always evaluates to the same value
< linting took 10279ms, errors: 395, warnings: 1527
---
> linting took 10898ms, errors: 395, warnings: 1521
```

Resolves #260 