### PR TITLE
`impl.linters`: unwrap redundant `and`

### DIFF
--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -26,7 +26,7 @@
                ctx
                (node->line (:filename ctx) condition :warning :cond-else
                            "use :else as the catch-all test expression in cond")))
-            (when (and (seq rest-conditions))
+            (when (seq rest-conditions)
               (findings/reg-finding!
                ctx
                (node->line (:filename ctx) (first rest-conditions) :warning


### PR DESCRIPTION
This is the only flaw Eastwood found in the codebase (other than a `clojure.core/type` shadowing in `defn reg-finding!` - not everyone likes those fixed, so I didn't out of caution)