### PR TITLE
Accept multiple --lint options

### DIFF
--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -50,28 +50,28 @@ Options:
                (if-let [opt (first options)]
                  (if (starts-with? opt "--")
                    (recur (rest options)
-                          (assoc opts-map opt [])
+                          (update opts-map opt (fnil identity []))
                           opt)
                    (recur (rest options)
                           (update opts-map current-opt conj opt)
                           current-opt))
                  opts-map))
-        default-lang (when-let [lang-opt (first (get opts "--lang"))]
+        default-lang (when-let [lang-opt (last (get opts "--lang"))]
                        (keyword lang-opt))
         cache-opt (get opts "--cache")]
     #_(binding [*out* *err*]
       (prn "cache opt" cache-opt))
     {:lint (get opts "--lint")
      :cache (if cache-opt
-              (if-let [f (first cache-opt)]
+              (if-let [f (last cache-opt)]
                 (cond (= "false" f) false
                       (= "true" f) true
                       :else f)
                 true)
               true)
-     :cache-dir (first (get opts "--cache-dir"))
+     :cache-dir (last (get opts "--cache-dir"))
      :lang default-lang
-     :config (first (get opts "--config"))
+     :config (last (get opts "--config"))
      :version (get opts "--version")
      :help (get opts "--help")}))
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2082,16 +2082,16 @@
     (when (.exists (io/file ".clj-kondo"))
       (rename-path ".clj-kondo" ".clj-kondo.bak"))
     (make-dirs ".clj-kondo")
-    (lint! "(ns app.core) (defn foo [])" "--cache")
+    (lint! "(ns app.core) (defn foo [])" "--cache" "true")
     (lint! "(ns app.api (:require [potemkin :refer [import-vars]]))
             (import-vars [app.core foo])"
-           "--cache")
+           "--cache" "true")
     (assert-submaps '({:file "<stdin>",
                        :row 1,
                        :col 49,
                        :level :error,
                        :message "app.core/foo is called with 1 arg but expects 0"})
-                    (lint! "(ns consumer (:require [app.api :refer [foo]])) (foo 1)" "--cache"))
+                    (lint! "(ns consumer (:require [app.api :refer [foo]])) (foo 1)" "--cache" "true"))
     (remove-dir ".clj-kondo")
     (when (.exists (io/file ".clj-kondo.bak"))
       (rename-path ".clj-kondo.bak" ".clj-kondo"))))
@@ -2425,6 +2425,13 @@
   (is (empty? (lint! "(get-in {} (keys-fn))" {:linters {:single-key-in {:level :warning}}})))
   (testing "don't throw exception when args are missing"
     (is (some? (lint! "(assoc-in)")))))
+
+(deftest multiple-lint-options
+  (let [out-str (with-out-str
+                  (main "--lint" "corpus/case.clj"
+                        "--lint" "corpus/defmulti.clj"))]
+    (is (str/includes? out-str "corpus/case.clj"))
+    (is (str/includes? out-str "corpus/defmulti.clj"))))
 
 ;;;; Scratch
 


### PR DESCRIPTION
Passing --lint src --lint test is an easy mistake to make.
This makes the command line parser treat it the same
as passing --lint src test