### PR TITLE
Add missing branch linter for if-* expressions

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1216,8 +1216,11 @@
                   (analyze-like-let ctx expr)
                   letfn
                   (analyze-letfn ctx expr)
-                  (if-let if-some when-let when-some when-first)
+                  (when-let when-some when-first)
                   (analyze-conditional-let ctx resolved-as-clojure-var-name expr)
+                  (if-some if-let)
+                  (do (analyze-conditional-let  ctx resolved-as-clojure-var-name expr)
+                      (analyze-if ctx expr))
                   do
                   (analyze-do ctx expr)
                   (fn fn* bound-fn)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1213,7 +1213,7 @@
                   (analyze-like-let ctx expr)
                   letfn
                   (analyze-letfn ctx expr)
-                  (if-some if-let when-let when-some when-first)
+                  (if-let if-some when-let when-some when-first)
                   (analyze-conditional-let ctx resolved-as-clojure-var-name expr)
                   do
                   (analyze-do ctx expr)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -600,14 +600,6 @@
        ctx
        (node->line (:filename ctx) expr :error :syntax (format "%s binding vector requires exactly 2 forms" form-name))))))
 
-(defn lint-one-or-two-forms-body! [ctx form-name main-expr body-exprs]
-  (let [num-children (count body-exprs)]
-    (when-not (or (= 1 num-children)
-                  (= 2 num-children))
-      (findings/reg-finding!
-       ctx
-       (node->line (:filename ctx) main-expr :error :syntax (format "%s body requires one or two forms" form-name))))))
-
 (defn analyze-conditional-let [ctx call expr]
   (let [children (next (:children expr))
         bv (first children)
@@ -621,8 +613,6 @@
                                                         :analyzed))
             if? (one-of call [if-let if-some])]
         (lint-two-forms-binding-vector! ctx call bv)
-        (when if?
-          (lint-one-or-two-forms-body! ctx call expr body-exprs))
         (concat (:analyzed bindings)
                 (analyze-expression** ctx condition)
                 (if if?

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -98,12 +98,15 @@
 (defn lint-missing-else-branch
   "Lint missing :else branch on if-like expressions"
   [ctx expr]
-  (let [children (:children expr)
-        args (rest children)]
-    (when (= (count args) 2)
-      (findings/reg-finding! ctx
-                             (node->line (:filename ctx) expr :warning :if
-                                             (format "Missing else branch."))))))
+  (let [config (:config ctx)
+        level (-> config :linters :if :level)]
+    (when-not (identical? :off level)
+      (let [children (:children expr)
+            args (rest children)]
+        (when (= (count args) 2)
+          (findings/reg-finding! ctx
+                                 (node->line (:filename ctx) expr level :if
+                                             (format "Missing else branch."))))))))
 
 #_(defn lint-test-is [ctx expr]
     (let [children (next (:children expr))]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2623,8 +2623,8 @@
       :level :warning,
       :message "Missing else branch."}]
     (lint! "(if true 1) (if-not true 1) (if-let [x 1] x) (if-some [x 1] x)"))
-  (empty? (lint! "(if true 1) (if-not true 1) (if-let [x 1] x) (if-some [x 1] x)"
-                 {:linters {:if {:level :off}}})))
+  (is (empty? (lint! "(if true 1) (if-not true 1) (if-let [x 1] x) (if-some [x 1] x)"
+                     {:linters {:if {:level :off}}}))))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -585,7 +585,7 @@
   (is (empty? (lint! "(defn foo [{:keys [select-keys :b]}]
     (let [x 1] (select-keys)))")))
   (is (seq (lint! "(defn foo ([select-keys]) ([x y] (select-keys)))")))
-  (is (empty? (lint! "(if-let [select-keys (fn [])] (select-keys))")))
+  (is (empty? (lint! "(if-let [select-keys (fn [])] (select-keys) :bar)")))
   (is (empty? (lint! "(when-let [select-keys (fn [])] (select-keys))")))
   (is (empty? (lint! "(fn foo [x] (foo x))")))
   (is (empty? (lint! "(fn select-keys [x] (select-keys 1))")))
@@ -720,15 +720,15 @@
        :row 1,
        :col 1,
        :level :error,
+       :message "if-some body requires one or two forms"}
+       {:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :error,
        :message "clojure.core/if-some is called with 1 arg but expects 2, 3 or more"}
        {:file "<stdin>",
         :row 1,
-        :col 1,
-        :level :error,
-        :message "if-some body requires one or two forms"}
-       {:file "<stdin>",
-        :row 1,
-        :col 9,
+        :col 10,
         :level :error,
         :message "if-some binding vector requires exactly 2 forms"})
     (lint! "(if-some [x 1 y 2])"))
@@ -745,7 +745,7 @@
         :message "if-some body requires one or two forms"}
        {:file "<stdin>",
         :row 1,
-        :col 9,
+        :col 10,
         :level :error,
         :message "if-some binding vector requires exactly 2 forms"})
     (lint! "(if-some [x 1 y])"))
@@ -1510,13 +1510,21 @@
    (lint! "(loop [x 1 y 2])"
           '{:linters {:unused-binding {:level :warning}}}))
   (assert-submaps
-   '({:file "<stdin>",
-      :row 1,
-      :col 10,
-      :level :warning,
-      :message "unused binding x"})
-   (lint! "(if-let [x 1] 1)"
-          '{:linters {:unused-binding {:level :warning}}}))
+    '({:file "<stdin>",
+       :row 1,
+       :col 10,
+       :level :warning,
+       :message "unused binding x"})
+    (lint! "(if-let [x 1] 1 2)"
+           '{:linters {:unused-binding {:level :warning}}}))
+  (assert-submaps
+    '({:file "<stdin>",
+       :row 1,
+       :col 11,
+       :level :warning,
+       :message "unused binding x"})
+    (lint! "(if-some [x 1] 1 2)"
+           '{:linters {:unused-binding {:level :warning}}}))
   (assert-submaps
    '({:file "<stdin>",
       :row 1,

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -705,7 +705,14 @@
         :level :error,
         :message "if-let binding vector requires exactly 2 forms"})
     (lint! "(if-let [x 1 y])"))
-  (is (empty? (lint! "(if-let [{:keys [:row :col]} {:row 1 :col 2}] row)"))))
+  (assert-submaps
+    '({:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :warning,
+       :message "Missing else branch."})
+    (lint! "(if-let [x 1] true)"))
+  (is (empty? (lint! "(if-let [{:keys [row col]} {:row 1 :col 2}] row 1)"))))
 
 (deftest if-some-test
   (assert-submaps
@@ -742,7 +749,14 @@
         :level :error,
         :message "if-some binding vector requires exactly 2 forms"})
     (lint! "(if-some [x 1 y])"))
-  (is (empty? (lint! "(if-some [{:keys [:row :col]} {:row 1 :col 2}] row)"))))
+  (assert-submaps
+    '({:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :warning,
+       :message "Missing else branch."})
+    (lint! "(if-let [x 1] true)"))
+  (is (empty? (lint! "(if-some [{:keys [row col]} {:row 1 :col 2}] row 1)"))))
 
 (deftest when-let-test
   (assert-submap

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2585,7 +2585,6 @@
   (:require [foo.bar]
             [bar.foo]))")))
 
-
 (deftest conflicting-aliases-test
   (assert-submaps
     [{:file "<stdin>", :row 1, :col 50,
@@ -2600,6 +2599,32 @@
                      {:linters {:conflicting-alias {:level :error}
                                 :unused-referred-var {:level :off}
                                 :unused-namespace {:level :off}}}))))
+
+(deftest missing-else-branch-test
+  (assert-submaps
+    [{:file "<stdin>",
+      :row 1,
+      :col 1,
+      :level :warning,
+      :message "Missing else branch."}
+     {:file "<stdin>",
+      :row 1,
+      :col 13,
+      :level :warning,
+      :message "Missing else branch."}
+     {:file "<stdin>",
+      :row 1,
+      :col 29,
+      :level :warning,
+      :message "Missing else branch."}
+     {:file "<stdin>",
+      :row 1,
+      :col 46,
+      :level :warning,
+      :message "Missing else branch."}]
+    (lint! "(if true 1) (if-not true 1) (if-let [x 1] x) (if-some [x 1] x)"))
+  (empty? (lint! "(if true 1) (if-not true 1) (if-let [x 1] x) (if-some [x 1] x)"
+                 {:linters {:if {:level :off}}})))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -679,11 +679,6 @@
        :message "clojure.core/if-let is called with 1 arg but expects 2, 3 or more"}
        {:file "<stdin>",
         :row 1,
-        :col 1,
-        :level :error,
-        :message "if-let body requires one or two forms"}
-       {:file "<stdin>",
-        :row 1,
         :col 9,
         :level :error,
         :message "if-let binding vector requires exactly 2 forms"})
@@ -694,11 +689,6 @@
        :col 1,
        :level :error,
        :message "clojure.core/if-let is called with 1 arg but expects 2, 3 or more"}
-       {:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :error,
-        :message "if-let body requires one or two forms"}
        {:file "<stdin>",
         :row 1,
         :col 9,
@@ -720,11 +710,6 @@
        :row 1,
        :col 1,
        :level :error,
-       :message "if-some body requires one or two forms"}
-       {:file "<stdin>",
-       :row 1,
-       :col 1,
-       :level :error,
        :message "clojure.core/if-some is called with 1 arg but expects 2, 3 or more"}
        {:file "<stdin>",
         :row 1,
@@ -738,11 +723,6 @@
        :col 1,
        :level :error,
        :message "clojure.core/if-some is called with 1 arg but expects 2, 3 or more"}
-       {:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :error,
-        :message "if-some body requires one or two forms"}
        {:file "<stdin>",
         :row 1,
         :col 10,

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -672,40 +672,77 @@
 
 (deftest if-let-test
   (assert-submaps
-   '({:file "<stdin>",
-      :row 1,
-      :col 1,
-      :level :error,
-      :message "clojure.core/if-let is called with 1 arg but expects 2, 3 or more"}
-     {:file "<stdin>",
-      :row 1,
-      :col 1,
-      :level :error,
-      :message "if-let body requires one or two forms"}
-     {:file "<stdin>",
-      :row 1,
-      :col 9,
-      :level :error,
-      :message "if-let binding vector requires exactly 2 forms"})
-   (lint! "(if-let [x 1 y 2])"))
+    '({:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :error,
+       :message "clojure.core/if-let is called with 1 arg but expects 2, 3 or more"}
+       {:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :error,
+        :message "if-let body requires one or two forms"}
+       {:file "<stdin>",
+        :row 1,
+        :col 9,
+        :level :error,
+        :message "if-let binding vector requires exactly 2 forms"})
+    (lint! "(if-let [x 1 y 2])"))
   (assert-submaps
-   '({:file "<stdin>",
-      :row 1,
-      :col 1,
-      :level :error,
-      :message "clojure.core/if-let is called with 1 arg but expects 2, 3 or more"}
-     {:file "<stdin>",
-      :row 1,
-      :col 1,
-      :level :error,
-      :message "if-let body requires one or two forms"}
-     {:file "<stdin>",
-      :row 1,
-      :col 9,
-      :level :error,
-      :message "if-let binding vector requires exactly 2 forms"})
-   (lint! "(if-let [x 1 y])"))
+    '({:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :error,
+       :message "clojure.core/if-let is called with 1 arg but expects 2, 3 or more"}
+       {:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :error,
+        :message "if-let body requires one or two forms"}
+       {:file "<stdin>",
+        :row 1,
+        :col 9,
+        :level :error,
+        :message "if-let binding vector requires exactly 2 forms"})
+    (lint! "(if-let [x 1 y])"))
   (is (empty? (lint! "(if-let [{:keys [:row :col]} {:row 1 :col 2}] row)"))))
+
+(deftest if-some-test
+  (assert-submaps
+    '({:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :error,
+       :message "clojure.core/if-some is called with 1 arg but expects 2, 3 or more"}
+       {:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :error,
+        :message "if-some body requires one or two forms"}
+       {:file "<stdin>",
+        :row 1,
+        :col 9,
+        :level :error,
+        :message "if-some binding vector requires exactly 2 forms"})
+    (lint! "(if-some [x 1 y 2])"))
+  (assert-submaps
+    '({:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :error,
+       :message "clojure.core/if-some is called with 1 arg but expects 2, 3 or more"}
+       {:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :error,
+        :message "if-some body requires one or two forms"}
+       {:file "<stdin>",
+        :row 1,
+        :col 9,
+        :level :error,
+        :message "if-some binding vector requires exactly 2 forms"})
+    (lint! "(if-some [x 1 y])"))
+  (is (empty? (lint! "(if-some [{:keys [:row :col]} {:row 1 :col 2}] row)"))))
 
 (deftest when-let-test
   (assert-submap
@@ -2318,22 +2355,41 @@
 
 (deftest if-test
   (assert-submaps
-   '({:file "<stdin>",
-      :row 1,
-      :col 1,
-      :level :error,
-      :message "Too few arguments to if."}
-     {:file "<stdin>",
-      :row 1,
-      :col 6,
-      :level :warning,
-      :message "Missing else branch."}
-     {:file "<stdin>",
-      :row 1,
-      :col 15,
-      :level :error,
-      :message "Too many arguments to if."})
-   (lint! "(if) (if 1 1) (if 1 1 1 1)")))
+    '({:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :error,
+       :message "Too few arguments to if."}
+       {:file "<stdin>",
+        :row 1,
+        :col 6,
+        :level :warning,
+        :message "Missing else branch."}
+       {:file "<stdin>",
+        :row 1,
+        :col 15,
+        :level :error,
+        :message "Too many arguments to if."})
+    (lint! "(if) (if 1 1) (if 1 1 1 1)")))
+
+(deftest if-not-test
+  (assert-submaps
+    '({:file "<stdin>",
+       :row 1,
+       :col 1,
+       :level :error,
+       :message "clojure.core/if-not is called with 0 args but expects 2 or 3"}
+       {:file "<stdin>",
+        :row 1,
+        :col 10,
+        :level :warning,
+        :message "Missing else branch."}
+       {:file "<stdin>",
+        :row 1,
+        :col 23,
+        :level :error,
+        :message "clojure.core/if-not is called with 4 args but expects 2 or 3"})
+    (lint! "(if-not) (if-not 1 1) (if-not 1 1 1 1)")))
 
 (deftest unused-private-var-test
   (assert-submaps

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1256,7 +1256,7 @@
   (is (empty? (lint! "(ns foo (:require [clojure.string :as str]))
                        (let [{:keys [:id] :or {id (str/lower-case \"HI\")}} {:id \"hello\"}] id)")))
   (is (empty? (lint! "(ns foo (:require [clojure.string :as str]))
-                       (if-let [{:keys [:id] :or {id (str/lower-case \"HI\")}} {:id \"hello\"}] id)")))
+                       (if-let [{:keys [:id] :or {id (str/lower-case \"HI\")}} {:id \"hello\"}] id :bar)")))
   (is (empty? (lint! "(ns foo (:require [clojure.string :as str]))
                        (loop [{:keys [:id] :or {id (str/lower-case \"HI\")}} {:id \"hello\"}])")))
   (is (empty? (lint! (io/file "corpus" "shadow_cljs" "default.cljs"))))


### PR DESCRIPTION
In this PR we:
- Extract the code for "Missing else branch" linter into its own function. Now the `analyze-if` will not complain about arity 2, which is not an error per se.
- The missing else branch linter (which needs to be renamed from `:if`, see #830) now respects the `:level` in the config.
- Added support for `if-not`, `if-some` and `if-let`, for the missing else branch linter, Fixes #791 
- Added tests for `if-some` and adapted ones of `if-let`