### PR TITLE
Add :refer linter, default off

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -38,7 +38,7 @@ Some linters are not enabled by default. Right now these linters are:
 
 - `:missing-docstring`: warn when public var doesn't have a docstring.
 - `:unsorted-required-namespaces`: warn when namespaces in `:require` are not sorted.
-- `:refer`: warn when there is **any** usage of `:refer` or `:refer-all` in your namespace requirements.
+- `:refer`: warn when there is **any** usage of `:refer` in your namespace requirements.
 - `:single-key-in`: warn when using assoc-in, update-in or get-in with single key
 
 You can enable these linters by setting the `:level`:

--- a/doc/config.md
+++ b/doc/config.md
@@ -38,6 +38,7 @@ Some linters are not enabled by default. Right now these linters are:
 
 - `:missing-docstring`: warn when public var doesn't have a docstring.
 - `:unsorted-required-namespaces`: warn when namespaces in `:require` are not sorted.
+- `:refer`: warn when there is **any** usage of `:refer` or `:refer-all` in your namespace requirements.
 - `:single-key-in`: warn when using assoc-in, update-in or get-in with single key
 
 You can enable these linters by setting the `:level`:

--- a/doc/config.md
+++ b/doc/config.md
@@ -38,7 +38,7 @@ Some linters are not enabled by default. Right now these linters are:
 
 - `:missing-docstring`: warn when public var doesn't have a docstring.
 - `:unsorted-required-namespaces`: warn when namespaces in `:require` are not sorted.
-- `:refer`: warn when there is **any** usage of `:refer` in your namespace requirements.
+- `:refer`: warn when there is **any** usage of `:refer` in your namespace requires.
 - `:single-key-in`: warn when using assoc-in, update-in or get-in with single key
 
 You can enable these linters by setting the `:level`:

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -225,6 +225,7 @@
                  analyzed))
              kw+libspecs)
         _ (doseq [analyzed analyzed]
+            (namespace/lint-refers! ctx analyzed)
             (namespace/lint-conflicting-aliases! ctx analyzed)
             (let [namespaces (map :ns analyzed)]
               (namespace/lint-unsorted-required-namespaces! ctx namespaces)

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -82,7 +82,8 @@
                        (when require-sym
                          (keyword require-sym)))
         use? (= :use require-kw)
-        libspec-meta (meta libspec-expr)]
+        libspec-meta (meta libspec-expr)
+        lint-refers? (not (identical? :off (-> ctx :config :linters :refer :level)))]
     (if-let [s (symbol-from-token libspec-expr)]
       [{:type :require
         :referred-all (when use? require-kw-expr)
@@ -120,30 +121,40 @@
                   child-k (:k child-expr)]
               (case child-k
                 (:refer :refer-macros :only)
-                (recur
-                 (nnext children)
-                 (cond (and (not self-require?) (sequential? opt))
-                       (let [;; undo referred-all when using :only with :use
-                             m (if (and use? (= :only child-k))
-                                 (do (findings/reg-finding!
-                                      ctx
-                                      (node->line
-                                       filename
-                                       (:referred-all m)
-                                       :warning
-                                       :use
-                                       (format "use %srequire with alias or :refer with [%s]"
-                                               (if require-sym
-                                                 "" ":")
-                                               (str/join " " (sort opt)))))
-                                     (dissoc m :referred-all))
-                                 m)]
-                         (update m :referred into
-                                 (map #(with-meta (sexpr %)
-                                         (meta %))) (:children opt-expr)))
-                       (= :all opt)
-                       (assoc m :referred-all opt-expr)
-                       :else m))
+                (do
+                  (when lint-refers?
+                    (findings/reg-finding!
+                     ctx
+                     (node->line (:filename ctx)
+                                 child-expr
+                                 :warning
+                                 :refer
+                                 (str (if use? "use" "require")
+                                      " with " (str child-k)))))
+                  (recur
+                   (nnext children)
+                   (cond (and (not self-require?) (sequential? opt))
+                         (let [;; undo referred-all when using :only with :use
+                               m (if (and use? (= :only child-k))
+                                   (do (findings/reg-finding!
+                                        ctx
+                                        (node->line
+                                         filename
+                                         (:referred-all m)
+                                         :warning
+                                         :use
+                                         (format "use %srequire with alias or :refer with [%s]"
+                                                 (if require-sym
+                                                   "" ":")
+                                                 (str/join " " (sort opt)))))
+                                       (dissoc m :referred-all))
+                                   m)]
+                           (update m :referred into
+                                   (map #(with-meta (sexpr %)
+                                           (meta %))) (:children opt-expr)))
+                         (= :all opt)
+                         (assoc m :referred-all opt-expr)
+                         :else m)))
                 :as (recur
                      (nnext children)
                      (assoc m :as (with-meta opt
@@ -225,7 +236,6 @@
                  analyzed))
              kw+libspecs)
         _ (doseq [analyzed analyzed]
-            (namespace/lint-refers! ctx analyzed)
             (namespace/lint-conflicting-aliases! ctx analyzed)
             (let [namespaces (map :ns analyzed)]
               (namespace/lint-unsorted-required-namespaces! ctx namespaces)

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -122,15 +122,14 @@
               (case child-k
                 (:refer :refer-macros :only)
                 (do
-                  (when lint-refers?
+                  (when (and lint-refers? (not use?))
                     (findings/reg-finding!
                      ctx
                      (node->line (:filename ctx)
                                  child-expr
                                  :warning
                                  :refer
-                                 (str (if use? "use" "require")
-                                      " with " (str child-k)))))
+                                 (str "require with " (str child-k)))))
                   (recur
                    (nnext children)
                    (cond (and (not self-require?) (sequential? opt))

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -66,9 +66,11 @@
                                     :exclude {#_#_taoensso.timbre [debug]}}
               :unused-private-var {:level :warning}
               :duplicate-require {:level :warning}
+              :refer {:level :off}
               :refer-all {:level :warning
                           :exclude #{}}
               :use {:level :warning}
+
               :missing-else-branch {:level :warning}
               :type-mismatch {:level :error}
               :missing-docstring {:level :off}

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -70,7 +70,6 @@
               :refer-all {:level :warning
                           :exclude #{}}
               :use {:level :warning}
-
               :missing-else-branch {:level :warning}
               :type-mismatch {:level :error}
               :missing-docstring {:level :off}

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -31,21 +31,6 @@
            namespaces)
    nil))
 
-(defn lint-refers! [ctx namespaces]
-  (let [config (:config ctx)
-        level (-> config :linters :refer :level)]
-    (when-not (identical? :off level)
-      (doseq [n namespaces]
-        (when (or (seq (:referred n))
-                  (seq (:referred-all n)))
-          (findings/reg-finding!
-              ctx
-              (node->line (:filename ctx)
-                          (:ns n)
-                          :warning
-                          :refer
-                          (str ":require with :refer"))))))))
-
 (defn lint-conflicting-aliases! [ctx namespaces]
   (let [config (:config ctx)
         level (-> config :linters :conflicting-alias :level)]
@@ -242,7 +227,6 @@
   [{:keys [:base-lang :lang :namespaces] :as ctx} ns-sym analyzed-require-clauses]
   (swap! namespaces update-in [base-lang lang ns-sym]
          (fn [ns]
-           (lint-refers! ctx (:required analyzed-require-clauses))
            (lint-conflicting-aliases! ctx (:required analyzed-require-clauses))
            (lint-unsorted-required-namespaces! ctx (:required analyzed-require-clauses))
            (lint-duplicate-requires! ctx (:required ns) (:required analyzed-require-clauses))

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2372,16 +2372,42 @@
 (deftest refer-test
   (is (empty? (lint! "(ns foo (:require [foo.bar :as foo] [foo.baz :refer [asd]])) (foo/bazbar) (asd)")))
   (assert-submaps
-    [{:file "<stdin>", :row 1, :col 38,
-      :level :warning, :message #":require with :refer"}]
+    [{:file "<stdin>", :row 1, :col 46,
+      :level :warning, :message #"require with :refer"}]
     (lint! "(ns foo (:require [foo.bar :as foo] [foo.baz :refer [asd]])) (foo/bazbar) (asd)"
            {:linters {:refer {:level :warning}}}))
   (assert-submaps
-    [{:file "<stdin>", :row 1, :col 38,
-      :level :warning, :message #":require with :refer"}]
+    [{:file "<stdin>", :row 1, :col 46,
+      :level :warning, :message #"require with :refer"}]
     (lint! "(ns foo (:require [foo.bar :as foo] [foo.baz :refer :all])) (foo/bazbar) (asd)"
            {:linters {:refer {:level :warning}
                       :refer-all {:level :off}}}))
+  (assert-submaps
+   [{:file "<stdin>", :row 1, :col 35,
+     :level :warning, :message #"require with :refer"}]
+   (lint! "(ns foo (:require-macros [foo.bar :refer [macro]])) (macro) "
+          {:linters {:refer {:level :warning}
+                     :refer-all {:level :off}}}
+          "--lang" "cljs"))
+  (assert-submaps
+   [{:file "<stdin>", :row 1, :col 28,
+     :level :warning, :message #"require with :refer-macros"}]
+   (lint! "(ns foo (:require [foo.bar :refer-macros [macro]])) (macro) "
+          {:linters {:refer {:level :warning}
+                     :refer-all {:level :off}}}
+          "--lang" "cljs"))
+  (assert-submaps
+   [{:file "<stdin>", :row 1, :col 20,
+     :level :warning, :message #"require with :refer"}]
+   (lint! "(require '[foo.bar :refer [macro]]) (macro) "
+          {:linters {:refer {:level :warning}
+                     :refer-all {:level :off}}}))
+  (assert-submaps
+   [{:file "<stdin>", :row 1, :col 16,
+     :level :warning, :message #"use with :only"}]
+   (lint! "(use '[foo.bar :only [macro]]) (macro) "
+          {:linters {:use {:level :off}
+                     :refer {:level :warning}}}))
   (is (empty? (lint! "(ns foo (:require [foo.bar :as foo])) (foo/bazbar)"
                      {:linters {:refer {:level :warning}}}))))
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2445,9 +2445,6 @@
   (testing "don't throw exception when args are missing"
     (is (some? (lint! "(assoc-in)")))))
 
-
-
-
 ;;;; Scratch
 
 (comment

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2355,11 +2355,11 @@
 
 (deftest conflicting-aliases-test
   (assert-submaps
-   [{:file "<stdin>", :row 1, :col 50,
-     :level :error, :message #"Conflicting alias for "}]
-   (lint! "(ns foo (:require [foo.bar :as bar] [baz.bar :as bar]))"
-          {:linters {:conflicting-alias {:level :error}
-                     :unused-namespace {:level :off}}}))
+    [{:file "<stdin>", :row 1, :col 50,
+      :level :error, :message #"Conflicting alias for "}]
+    (lint! "(ns foo (:require [foo.bar :as bar] [baz.bar :as bar]))"
+           {:linters {:conflicting-alias {:level :error}
+                      :unused-namespace {:level :off}}}))
   (is (empty? (lint! "(ns foo (:require [foo.bar :as foo] [baz.bar :as baz]))"
                      {:linters {:conflicting-alias {:level :error}
                                 :unused-namespace {:level :off}}})))
@@ -2367,6 +2367,25 @@
                      {:linters {:conflicting-alias {:level :error}
                                 :unused-referred-var {:level :off}
                                 :unused-namespace {:level :off}}}))))
+
+
+(deftest refer-test
+  (is (empty? (lint! "(ns foo (:require [foo.bar :as foo] [foo.baz :refer [asd]])) (foo/bazbar) (asd)")))
+  (assert-submaps
+    [{:file "<stdin>", :row 1, :col 38,
+      :level :warning, :message #":require with :refer"}]
+    (lint! "(ns foo (:require [foo.bar :as foo] [foo.baz :refer [asd]])) (foo/bazbar) (asd)"
+           {:linters {:refer {:level :warning}}}))
+  (assert-submaps
+    [{:file "<stdin>", :row 1, :col 38,
+      :level :warning, :message #":require with :refer"}]
+    (lint! "(ns foo (:require [foo.bar :as foo] [foo.baz :refer :all])) (foo/bazbar) (asd)"
+           {:linters {:refer {:level :warning}
+                      :refer-all {:level :off}}}))
+  (is (empty? (lint! "(ns foo (:require [foo.bar :as foo])) (foo/bazbar)"
+                     {:linters {:refer {:level :warning}}}))))
+
+
 
 (deftest missing-else-branch-test
   (assert-submaps
@@ -2425,6 +2444,9 @@
   (is (empty? (lint! "(get-in {} (keys-fn))" {:linters {:single-key-in {:level :warning}}})))
   (testing "don't throw exception when args are missing"
     (is (some? (lint! "(assoc-in)")))))
+
+
+
 
 ;;;; Scratch
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2402,12 +2402,6 @@
    (lint! "(require '[foo.bar :refer [macro]]) (macro) "
           {:linters {:refer {:level :warning}
                      :refer-all {:level :off}}}))
-  (assert-submaps
-   [{:file "<stdin>", :row 1, :col 16,
-     :level :warning, :message #"use with :only"}]
-   (lint! "(use '[foo.bar :only [macro]]) (macro) "
-          {:linters {:use {:level :off}
-                     :refer {:level :warning}}}))
   (is (empty? (lint! "(ns foo (:require [foo.bar :as foo])) (foo/bazbar)"
                      {:linters {:refer {:level :warning}}}))))
 


### PR DESCRIPTION
Fix for #847 

This linter will warn with **any** usage of `:refer` or `:refer-all` in `:require` clause.

We already have a `:refer-all` linter, which is similar but dedicated to refer-alls (I didn't touch it).