### PR TITLE
Support multiple options in cli arguments

### DIFF
--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -43,6 +43,15 @@ Options:
 
 ;;;; parse command line options
 
+(def opt-type
+  {"--help"      :scalar
+   "--version"   :scalar
+   "--lang"      :scalar
+   "--cache"     :scalar
+   "--cache-dir" :scalar
+   "--lint"      :coll
+   "--config"    :coll})
+
 (defn- parse-opts [options]
   (let [opts (loop [options options
                     opts-map {}
@@ -51,7 +60,9 @@ Options:
                  (if (starts-with? opt "--")
                    (recur (rest options)
                           ;; assoc nil value to indicate opt as explicitly added via cli args
-                          (update opts-map opt identity)
+                          (case (opt-type opt)
+                            :scalar (assoc opts-map opt nil)
+                            :coll (update opts-map opt identity))
                           opt)
                    (recur (rest options)
                           (update opts-map current-opt (fnil conj []) opt)

--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -59,12 +59,12 @@ Options:
                  opts-map))
         default-lang (when-let [lang-opt (last (get opts "--lang"))]
                        (keyword lang-opt))
-        cache-opt (get opts "--cache")]
+        cache-opt? (contains? opts "--cache")]
     #_(binding [*out* *err*]
       (prn "cache opt" cache-opt))
     {:lint (distinct (get opts "--lint"))
-     :cache (if cache-opt
-              (if-let [f (last cache-opt)]
+     :cache (if cache-opt?
+              (if-let [f (last (get opts "--cache"))]
                 (cond (= "false" f) false
                       (= "true" f) true
                       :else f)

--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -60,7 +60,7 @@ Options:
                  (if (starts-with? opt "--")
                    (recur (rest options)
                           ;; assoc nil value to indicate opt as explicitly added via cli args
-                          (case (opt-type opt)
+                          (case (opt-type opt :scalar)
                             :scalar (assoc opts-map opt nil)
                             :coll (update opts-map opt identity))
                           opt)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2465,6 +2465,32 @@
   (testing "don't throw exception when args are missing"
     (is (some? (lint! "(assoc-in)")))))
 
+(deftest multiple-options-test
+
+  (testing "multiple --lint option"
+    (let [out (read-string
+               (with-out-str
+                 (main "--lint" "corpus/case.clj"
+                       "--lint" "corpus/defmulti.clj"
+                       "--config" "{:output {:format :edn}}")))]
+
+      (is (= #{"corpus/case.clj" "corpus/defmulti.clj"}
+             (sequence (comp (map :filename) (distinct)) (:findings out))))
+
+      (is (= {:error 6 :warning 2 :info 0}
+             (select-keys (:summary out) [:error :warning :info])))))
+
+  (testing "multiple --config option"
+    (let [out (read-string
+               (with-out-str
+                 (main "--lint" "corpus/case.clj"
+                       "--lint" "corpus/defmulti.clj"
+                       "--config" "{:output {:format :edn}}"
+                       "--config" "{:inters {:invalid-arity {:level :warning}}}")))]
+
+      (is (= {:error 1 :warning 7 :info 0}
+             (select-keys (:summary out) [:error :warning :info]))))))
+
 ;;;; Scratch
 
 (comment

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2475,7 +2475,7 @@
                        "--config" "{:output {:format :edn}}")))]
 
       (is (= #{"corpus/case.clj" "corpus/defmulti.clj"}
-             (sequence (comp (map :filename) (distinct)) (:findings out))))
+             (into #{} (comp (map :filename) (distinct)) (:findings out))))
 
       (is (= {:error 6 :warning 2 :info 0}
              (select-keys (:summary out) [:error :warning :info])))))
@@ -2486,7 +2486,7 @@
                  (main "--lint" "corpus/case.clj"
                        "--lint" "corpus/defmulti.clj"
                        "--config" "{:output {:format :edn}}"
-                       "--config" "{:inters {:invalid-arity {:level :warning}}}")))]
+                       "--config" "{:linters {:invalid-arity {:level :warning}}}")))]
 
       (is (= {:error 1 :warning 7 :info 0}
              (select-keys (:summary out) [:error :warning :info]))))))


### PR DESCRIPTION
Solves #862 and #824 

values of multiple --lint and --config options will be conjoined and merged
options that are not supposed to have multiple values such as cache-dir will be
overriden with the right-most value

Examples:

  * `--lint foo.clj bar.clj --lint src` -> `["foo.clj" "bar.clj" "src"]`
  * `--config edn-str-1 --config edn-str-2` -> `(merge edn-1 edn2)`
  * `--cache false --cache` -> `true`
  * `--cache-dir some/dir --cache-dir another/dir` -> `another/dir`