### PR TITLE
[#773] Add linting for missing clause in try

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -826,23 +826,34 @@
          analyzed []
          ;; TODO: lint syntax
          _catch-phase false
-         _finally-phase false]
+         _finally-phase false
+         has-catch-or-finally? false]
     (if fst-child
       (case (symbol-call fst-child)
         catch
         (let [analyzed-catch (analyze-catch ctx fst-child)]
           (recur rst-children (into analyzed analyzed-catch)
-                 true false))
+                 true false true))
         finally
         (recur
          rst-children
          (into analyzed (analyze-children ctx (next (:children fst-child))))
-         false false)
+         false false true)
         (recur
          rst-children
          (into analyzed (analyze-expression** ctx fst-child))
-         false false))
-      analyzed)))
+         false false has-catch-or-finally?))
+      (do
+        (when-not has-catch-or-finally?
+          (findings/reg-finding!
+            ctx
+            (node->line
+              (:filename ctx)
+              expr
+              :warning
+              :missing-clause-in-try
+              "Missing catch or finally in try")))
+        analyzed))))
 
 (defn analyze-defprotocol [{:keys [:ns] :as ctx} expr]
   ;; for syntax, see https://clojure.org/reference/protocols#_basics

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -79,7 +79,8 @@
                                  :aliases {#_clojure.string #_str}}
               :unused-import {:level :warning}
               :single-operand-comparison {:level :warning}
-              :single-key-in {:level :off}}
+              :single-key-in {:level :off}
+              :missing-clause-in-try {:level :warning}}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>
               rewrite-clj.custom-zipper.core/defn-switchable clojure.core/defn

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -193,7 +193,7 @@
 
 (defn- lint-missing-clause-in-try
   [call]
-  (when (utils/one-of (:name call) [try try+])
+  (when (= (:name call) 'try)
     (let [clauses #{'catch 'finally}
           tokens (->> (get-in call [:expr :children])
                    rest

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -191,22 +191,6 @@
                    (str ns-name "/" fn-name)
                    (some? const-true))))))))
 
-(defn- lint-missing-clause-in-try
-  [call]
-  (when (= (:name call) 'try)
-    (let [clauses #{'catch 'finally}
-          tokens (->> (get-in call [:expr :children])
-                   rest
-                   (map utils/symbol-call)
-                   (set))]
-      (when-not (seq (set/intersection tokens clauses))
-        (node->line
-          (:filename call)
-          (:expr call)
-          :warning
-          :missing-clause-in-try
-          "Missing catch or finally in try")))))
-
 (defn lint-var-usage
   "Lints calls for arity errors, private calls errors. Also dispatches
   to call-specific linters."
@@ -317,10 +301,6 @@
                              (and call?
                                   (not (utils/linter-disabled? call :single-operand-comparison))
                                   (lint-single-operand-comparison call))
-                             missing-clause-in-try-error
-                             (and call?
-                                  (not (utils/linter-disabled? call :missing-clause-in-try))
-                                  (lint-missing-clause-in-try call))
                              errors
                              [(when arity-error?
                                 {:filename filename
@@ -332,8 +312,6 @@
                                  :message (arity-error fn-ns fn-name arity fixed-arities varargs-min-arity)})
                               (when single-operand-comparison-error
                                 single-operand-comparison-error)
-                              (when missing-clause-in-try-error
-                                missing-clause-in-try-error)
                               (when (and (:private called-fn)
                                          (not= caller-ns-sym
                                                fn-ns)

--- a/test/clj_kondo/missing_clause_in_try_test.clj
+++ b/test/clj_kondo/missing_clause_in_try_test.clj
@@ -1,0 +1,44 @@
+(ns clj-kondo.missing-clause-in-try-test
+  (:require
+   [clj-kondo.test-utils :refer [lint! assert-submaps]]
+   [clojure.test :as t :refer [deftest is testing]]))
+
+(deftest missing-clause-in-try-error-test
+  (testing "test linting error of missing clause in try for clojure"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Missing catch or finally in try"})
+     (lint! "(try (/ 1 0))")))
+
+  (testing "test linting error of missing clause in try with several exprs"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Missing catch or finally in try"})
+     (lint! "(try (/ 1 0) (prn \"test\"))")))
+
+  (testing "test linting error of missing clause in try for cljs"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Missing catch or finally in try"})
+     (lint! "(try (/ 1 0))" "--lang" "cljs"))))
+
+(deftest missing-clause-in-try-valid-test
+  (testing "test linting try with catch"
+    (is (empty? (lint! "(try
+                          (/ 1 0)
+                          (catch Exception e (prn \"Caught\")))"))))
+  (testing "test linting try with finally"
+    (is (empty? (lint! "(try
+                          (/ 1 0)
+                          (finally (prn \"Do something always\")))"))))
+  (testing "test linting try with multiple catch"
+    (is (empty? (lint! "(try
+                          (/ 1 0)
+                          (catch AssertionError e (prn \"Assertion\"))
+                          (catch Exception e (prn \"Caught\")))"))))
+  (testing "test linting try with multiple catch and finally"
+    (is (empty? (lint! "(try
+                          (/ 1 0)
+                          (catch AssertionError e (prn \"Assertion\"))
+                          (catch Exception e (prn \"Caught\"))
+                          (finally (prn \"Do something always\")))")))))

--- a/test/clj_kondo/missing_clause_in_try_test.clj
+++ b/test/clj_kondo/missing_clause_in_try_test.clj
@@ -20,7 +20,35 @@
     (assert-submaps
      '({:file "<stdin>", :row 1, :col 1, :level :warning,
         :message "Missing catch or finally in try"})
-     (lint! "(try (/ 1 0))" "--lang" "cljs"))))
+     (lint! "(try (/ 1 0))" "--lang" "cljs")))
+  (testing "test linting error for first level in nested try"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Missing catch or finally in try"})
+     (lint! "(try
+               (/ 1 0)
+               (try
+                 (prn 11)
+                 (finally Exception e (prn 22))))")))
+  (testing "test linting error on second level in nested try in catch"
+    (assert-submaps
+     '({:file "<stdin>", :row 4, :col 18, :level :warning,
+        :message "Missing catch or finally in try"})
+     (lint! "(try
+               (/ 1 0)
+               (catch Exception e
+                 (try
+                   (prn 11))))")))
+  (testing "test linting error for both levels in nested try"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Missing catch or finally in try"}
+       {:file "<stdin>", :row 3, :col 16, :level :warning,
+        :message "Missing catch or finally in try"})
+     (lint! "(try
+               (/ 1 0)
+               (try
+                 (prn 11)))"))))
 
 (deftest missing-clause-in-try-valid-test
   (testing "test linting try with catch"
@@ -41,4 +69,18 @@
                           (/ 1 0)
                           (catch AssertionError e (prn \"Assertion\"))
                           (catch Exception e (prn \"Caught\"))
-                          (finally (prn \"Do something always\")))")))))
+                          (finally (prn \"Do something always\")))"))))
+  (testing "test linting nested try in body with clauses"
+    (is (empty? (lint! "(try
+                          (/ 1 0)
+                          (try
+                            (prn 11)
+                            (finally Exception e (prn 22)))
+                          (catch Exception e (prn \"Caought\")))"))))
+  (testing "test linting nested try in catch with clauses"
+    (is (empty? (lint! "(try
+                          (/ 1 0)
+                          (catch Exception e
+                            (try
+                              (prn 11)
+                              (finally Exception e (prn 22)))))")))))


### PR DESCRIPTION
Request adds linting for cases when try is used without any clause `catch` or `finally`.

Linting diff:
```
(missing-clause-in-try ✓) clj-kondo script/diff
Linting and writing output to /tmp/clj-kondo-diff/branch.txt
Cloning into 'clj-kondo'...
remote: Enumerating objects: 69, done.
remote: Counting objects: 100% (69/69), done.
remote: Compressing objects: 100% (46/46), done.
remote: Total 7214 (delta 23), reused 43 (delta 11), pack-reused 7145
Receiving objects: 100% (7214/7214), 8.03 MiB | 1.28 MiB/s, done.
Resolving deltas: 100% (4153/4153), done.
Linting and writing output to /tmp/clj-kondo-diff/master.txt
198d197
< cljs/closure.clj:1969:3: warning: Missing catch or finally in try
1941c1940
< linting took 10927ms, errors: 395, warnings: 1545
---
> linting took 10207ms, errors: 395, warnings: 1544
```

Resolves #773 