### PR TITLE
[#558] Add linting for missing body in when

### DIFF
--- a/corpus/redundant_do.clj
+++ b/corpus/redundant_do.clj
@@ -5,7 +5,7 @@
 (defn foo [] (do 1 2 3))
 (fn [] (do 1 2))
 (let [x 1] 1 2 (do 1 2 3))
-(when (do 1 2 3)) ;; no mention of redundant do
+(when (do 1 2 3)) ;; no mention of redundant do but mention of missing body in when
 (when :foo (do 1 2 3))
 (when-not :foo (do 1 2 3))
 (future (do 1 2))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1074,7 +1074,16 @@
             ;; avoid redundant do check for condition
             (update ctx :callstack conj nil)
             condition))
-    (analyze-children ctx body false)))
+    (if-not (seq body)
+      (findings/reg-finding!
+        ctx
+        (node->line
+          (:filename ctx)
+          expr
+          :warning
+          :missing-body-in-when
+          "Missing body in when"))
+      (analyze-children ctx body false))))
 
 (defn analyze-clojure-string-replace [ctx expr]
   (let [children (next (:children expr))

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -80,7 +80,8 @@
               :unused-import {:level :warning}
               :single-operand-comparison {:level :warning}
               :single-key-in {:level :off}
-              :missing-clause-in-try {:level :warning}}
+              :missing-clause-in-try {:level :warning}
+              :missing-body-in-when {:level :warning}}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>
               rewrite-clj.custom-zipper.core/defn-switchable clojure.core/defn

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -61,6 +61,7 @@
      {:row 5, :col 14, :file "corpus/redundant_do.clj" :message "redundant do"}
      {:row 6, :col 8, :file "corpus/redundant_do.clj" :message "redundant do"}
      {:row 7, :col 16, :file "corpus/redundant_do.clj" :message "redundant do"}
+     {:row 8, :col 1, :file "corpus/redundant_do.clj" :message "Missing body in when"}
      {:row 9, :col 12, :file "corpus/redundant_do.clj" :message "redundant do"}
      {:row 10, :col 16, :file "corpus/redundant_do.clj" :message "redundant do"}
      {:row 11, :col 9, :file "corpus/redundant_do.clj" :message "redundant do"}

--- a/test/clj_kondo/missing_body_in_when_test.clj
+++ b/test/clj_kondo/missing_body_in_when_test.clj
@@ -1,0 +1,29 @@
+(ns clj-kondo.missing-body-in-when-test
+  (:require
+   [clj-kondo.test-utils :refer [lint! assert-submaps]]
+   [clojure.test :as t :refer [deftest is testing]]))
+
+(deftest missing-body-in-when-error-test
+  (testing "test linting error of missing body in when for clojure"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Missing body in when"})
+     (lint! "(when (> 1 0))")))
+  (testing "test linting error of missing body in when for cljs"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Missing body in when"})
+     (lint! "(when true)" "--lang" "cljs")))
+  (testing "test linting error of missing body in nested when"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 15, :level :warning,
+        :message "Missing body in when"})
+     (lint! "(when (> 1 0) (when (= 1 2)))"))))
+
+(deftest missing-body-in-when-valid-test
+  (testing "test linting when with condition and body"
+    (is (empty? (lint! "(when (> 1 0) (prn 1))"))))
+  (testing "test linting when with multiple expresion in body"
+    (is (empty? (lint! "(when true (prn 1) (+ 1 1))"))))
+  (testing "test linting nested when"
+    (is (empty? (lint! "(when (> 1 0) (when (prn 1) (+ 1 1)))")))))


### PR DESCRIPTION
Request adds linting for `when` expressions with empty body.
```
(missing-body-in-when ✓) clj-kondo script/diff
Linting and writing output to /tmp/clj-kondo-diff/branch.txt
Cloning into 'clj-kondo'...
remote: Enumerating objects: 86, done.
remote: Counting objects: 100% (86/86), done.
remote: Compressing objects: 100% (58/58), done.
remote: Total 7231 (delta 29), reused 52 (delta 13), pack-reused 7145
Receiving objects: 100% (7231/7231), 8.06 MiB | 2.24 MiB/s, done.
Resolving deltas: 100% (4159/4159), done.
Linting and writing output to /tmp/clj-kondo-diff/master.txt
1941c1941
< linting took 10302ms, errors: 395, warnings: 1545
---
> linting took 10896ms, errors: 395, warnings: 1545
```