### PR TITLE
Bump up datalog-parser to 0.1.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "parser" "resources" "inlined"]
  :deps {com.cognitect/transit-clj {:mvn/version "0.8.313"}
-        io.lambdaforge/datalog-parser {:mvn/version "0.1.1"}
+        io.lambdaforge/datalog-parser {:mvn/version "0.1.3"}
         cheshire {:mvn/version "5.8.1"}
         nrepl/bencode {:mvn/version "1.1.0"}}
  :aliases {:clj-kondo

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
   :source-paths ["src" "parser" "inlined"]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [com.cognitect/transit-clj "0.8.313"]
-                 [io.lambdaforge/datalog-parser "0.1.1"]
+                 [io.lambdaforge/datalog-parser "0.1.3"]
                  [cheshire "5.8.1"]
                  [nrepl/bencode "1.1.0"]]
   :profiles {:clojure-1.9.0 {:dependencies [[org.clojure/clojure "1.9.0"]]}


### PR DESCRIPTION
See #889 

The new datalog-parser version fixes or-join semantics.

Before:

```
clojure -A:clj-kondo --lint - <<< "
(ns group
  (:require [datomic.api :as d]))

(defn can-access-group? [db user-id group-id]
  (boolean
   (d/q '[:find ?user-id .
          :in $ ?user-id ?group-id
          :where [?user :user/id ?user-id]
                 (or-join [?user ?group-id]
                          (and [?user :user/group ?g]
                               [?g :group/id ?group-id])
                          [?user :user/admin true])]
        db user-id group-id)))
"

<stdin>:7:9: error: Join variable not declared inside clauses: [?group-id]
linting took 102ms, errors: 1, warnings: 0
```

After:

```
clojure -A:clj-kondo --lint - <<< "
(ns group
  (:require [datomic.api :as d]))

(defn can-access-group? [db user-id group-id]
  (boolean
   (d/q '[:find ?user-id .
          :in $ ?user-id ?group-id
          :where [?user :user/id ?user-id]
                 (or-join [?user ?group-id]
                          (and [?user :user/group ?g]
                               [?g :group/id ?group-id])
                          [?user :user/admin true])]
        db user-id group-id)))
"

linting took 105ms, errors: 0, warnings: 0
```