### PR TITLE
docs: note that JDK 8 / 11 based graal is required

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -5,6 +5,8 @@
 To build the `clj-kondo` binary from source:
 
 * Download [GraalVM](https://github.com/graalvm/graalvm-ce-builds/releases) java8 19 or newer.
+  Currently `clj-kondo` can only be built with java11 based graal VMs, so using JDK 8 builds will
+  not work.
 
 * Set the `GRAALVM_HOME` variable. E.g.:
 
@@ -20,7 +22,7 @@ Place the binary somewhere on your path.
 
 ### Optional steps
 
-These steps are only necessary to update resources that are shipped with clj-kondo. 
+These steps are only necessary to update resources that are shipped with clj-kondo.
 
 * To update the built-in cache for Clojure and ClojureScript:
 


### PR DESCRIPTION
Makes a note that currently only JDK 8 based graal VMs are supported.

Since many clojure devs aren't yet familiar with compiling native
images it's nice to help them stay on a safe path that works.