### PR TITLE
Provide option to pin install to a specific version

### DIFF
--- a/doc/companies.md
+++ b/doc/companies.md
@@ -29,6 +29,7 @@ listed!
 - [Metosin](https://www.metosin.fi)
 - [NextJournal](https://nextjournal.com)
 - [Nubank](https://www.nubank.com.br)
+- [Reify Health](https://www.reifyhealth.com/)
 - [Sharetribe](https://www.sharetribe.com)
 - [Solita](https://www.solita.fi/en/)
 - [SUPREMATIC](https://suprematic.de/company/)

--- a/script/install-clj-kondo
+++ b/script/install-clj-kondo
@@ -9,16 +9,18 @@ default_install_dir="/usr/local/bin"
 install_dir=$default_install_dir
 default_download_dir="/tmp"
 download_dir=$default_download_dir
+release_version=""
 
 print_help() {
     echo "Installs latest version of clj-kondo."
     echo -e
     echo "Usage:"
-    echo "install [--dir <dir>] [--download-dir <download-dir>]"
+    echo "install [--dir <dir>] [--download-dir <download-dir>] [--release-version <version>]"
     echo -e
     echo "Defaults:"
     echo " * Installation directory: ${default_install_dir}"
     echo " * Download directory: ${default_download_dir}"
+    echo " * Release version: <Latest release on github>"
     exit 1
 }
 
@@ -40,6 +42,11 @@ do
             shift
             shift
             ;;
+        --release-version)
+            release_version="$2"
+            shift
+            shift
+            ;;
         *)    # unknown option
             print_help
             shift
@@ -47,20 +54,22 @@ do
     esac
 done
 
-latest_release="$(curl -s https://raw.githubusercontent.com/borkdude/clj-kondo/master/resources/CLJ_KONDO_RELEASED_VERSION)"
+if [[ "$release_version" == "" ]]; then
+  release_version="$(curl -s https://raw.githubusercontent.com/borkdude/clj-kondo/master/resources/CLJ_KONDO_RELEASED_VERSION)"
+fi
 
 case "$(uname -s)" in
     Linux*)     platform=linux;;
     Darwin*)    platform=macos;;
 esac
 
-download_url="https://github.com/borkdude/clj-kondo/releases/download/v$latest_release/clj-kondo-$latest_release-$platform-amd64.zip"
+download_url="https://github.com/borkdude/clj-kondo/releases/download/v$release_version/clj-kondo-$release_version-$platform-amd64.zip"
 
 cd "$download_dir"
 echo -e "Downloading $download_url to $download_dir"
-curl -o "clj-kondo-$latest_release-$platform-amd64.zip" -sL "https://github.com/borkdude/clj-kondo/releases/download/v$latest_release/clj-kondo-$latest_release-$platform-amd64.zip"
-unzip -qqo "clj-kondo-$latest_release-$platform-amd64.zip"
-rm "clj-kondo-$latest_release-$platform-amd64.zip"
+curl -o "clj-kondo-$release_version-$platform-amd64.zip" -sL "https://github.com/borkdude/clj-kondo/releases/download/v$release_version/clj-kondo-$release_version-$platform-amd64.zip"
+unzip -qqo "clj-kondo-$release_version-$platform-amd64.zip"
+rm "clj-kondo-$release_version-$platform-amd64.zip"
 
 cd "$install_dir"
 if [ -f clj-kondo ]; then


### PR DESCRIPTION
Hi borkdude.
 Thanks for the wonderful linter. We use it at work :) I'd like to propose a --release-version flag to the install script in order to pin the version. The use case for this is that we want to rely on a pinned version to avoid any accidental bugs in the latest version. In particular, we got bit by https://github.com/borkdude/clj-kondo/issues/944 which led to some CI churn.

Example usage: `script/install-clj-kondo --dir $PWD/foo --release-version 2020.06.12`

Thoughts? Happy to change the option name to whatever you prefer.

Cheers, Gabriel