### PR TITLE
Add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: clj-kondo
+  name: clj-kondo
+  description: A linter for Clojure code that sparks joy
+  entry: --entrypoint clj-kondo borkdude/clj-kondo:2020.07.26 --lint
+  language: docker_image
+  files: \.(clj[sc]|edn)?$


### PR DESCRIPTION
A simple configuration file for [pre-commit](https://pre-commit.com/) that allows clj-kondo to be run as, well, a pre-commit hook!