### PR TITLE
Remove trailing dot from url in help message

### DIFF
--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -36,7 +36,7 @@ Options:
   nearest `.clj-kondo` directory in the current and parent directories.
 
   --config <config>: config may be a file or an EDN expression. See
-    https://cljdoc.org/d/clj-kondo/clj-kondo/%s/doc/configuration.
+    https://cljdoc.org/d/clj-kondo/clj-kondo/%s/doc/configuration
 
   --config-dir <config-dir>: use this config directory instead of auto-detected
     .clj-kondo dir.


### PR DESCRIPTION
When copy pasting the url from the terminal (e.g. by double-clicking + ctr-c/cmd-c) the dot gets included and you end up at a [non-existing page](https://cljdoc.org/d/clj-kondo/clj-kondo/2020.06.21/doc/configuration.) instead of [target page](https://cljdoc.org/d/clj-kondo/clj-kondo/2020.06.21/doc/configuration).

This commit removes that dot to fix this situation. Here is [some background](https://www.punctuationmatters.com/should-i-use-punctuation-after-a-url/) on this issue. Apparently other tools can deal with this, my terminal not yet