### PR TITLE
[#1010] fix for deftest false positive unresolved-symbol

### DIFF
--- a/corpus/deftest_resolve_test_name_fail.clj
+++ b/corpus/deftest_resolve_test_name_fail.clj
@@ -1,0 +1,6 @@
+(ns deftest-resolve-test-name-fail
+  (:require [clojure.string :refer :all]
+            [clojure.test :refer :all]))
+(deftest my-test
+  (is (blank? ""))
+  (is (thrown? (throw (Exception.)))))

--- a/corpus/deftest_resolve_test_name_pass.clj
+++ b/corpus/deftest_resolve_test_name_pass.clj
@@ -1,0 +1,6 @@
+(ns deftest-resolve-test-name-pass
+  (:require [clojure.test :refer :all]
+            [clojure.string :refer :all]))
+(deftest my-test
+  (is (blank? ""))
+  (is (thrown? (throw (Exception.)))))

--- a/test/clj_kondo/impl/namespace_test.clj
+++ b/test/clj_kondo/impl/namespace_test.clj
@@ -54,10 +54,11 @@
                                        [baz :refer :all :rename {baz-fn renamed-fn}]))")))))
 
 (deftest resolve-name-test
-  (let [ctx {:namespaces (atom {})
-             :findings (atom [])
-             :base-lang :clj
-             :lang :clj}
+  (let [new-ctx (fn [] {:namespaces (atom {})
+                        :findings   (atom [])
+                        :base-lang  :clj
+                        :lang       :clj})
+        ctx (new-ctx)
         _ (analyze-ns-decl
            ctx
            (parse-string "(ns foo (:require [bar :as baz :refer [quux]]))"))]
@@ -92,7 +93,60 @@
 "))]
         (is (=
              '{:ns clojure.core :name inc}
-             (resolve-name ctx 'clj-kondo.impl.utils 'clojure.core/inc)))))))
+             (resolve-name ctx 'clj-kondo.impl.utils 'clojure.core/inc)))))
+    (testing "referring all"
+      (let [code (str "(ns clj-kondo.impl.utils "
+                      "  (:require [clojure.test :refer :all])) "
+                      "(deftest my-test)")]
+        (analyze-ns-decl ctx (parse-string code))
+        (is (= '{:ns clojure.test
+                 :name deftest
+                 :unresolved? true
+                 :clojure-excluded? false}
+               (resolve-name ctx 'clj-kondo.impl.utils 'deftest)))))
+    (testing "referring all for more than one namespace"
+      (let [code (str "(ns clj-kondo.impl.utils "
+                      "  (:require [clojure.test :refer :all]"
+                      "            [clojure.string :refer :all])) "
+                      "(deftest my-test (is (blank? \"\")))")]
+        (let [ctx (new-ctx)]
+          (analyze-ns-decl ctx (parse-string code))
+          (is (= '{:ns clojure.test
+                   :name deftest
+                   :unresolved? true
+                   :clojure-excluded? false}
+                 (resolve-name ctx 'clj-kondo.impl.utils 'deftest))))
+        (let [ctx (new-ctx)]
+          (analyze-ns-decl ctx (parse-string code))
+          ;; A known deficiency; unless specifically declared in
+          ;; `clj-kondo.impl.namespace/resolve-referred-all-ns`,
+          ;; any un-namespaced symbols will be assigned the first
+          ;; refer-all in the requires list. In this case, `blank?`
+          ;; belongs to `clojure.string`, but in this context, there
+          ;; is no way to know that.
+          (is (= '{:ns clojure.test
+                   :name blank?
+                   :unresolved? true
+                   :clojure-excluded? false}
+                 (resolve-name ctx 'clj-kondo.impl.utils 'blank?)))))
+      (let [code (str "(ns clj-kondo.impl.utils "
+                      "  (:require [clojure.string :refer :all]"
+                      "            [clojure.test :refer :all])) "
+                      "(deftest my-test (is (blank? \"\")))")]
+        (let [ctx (new-ctx)]
+          (analyze-ns-decl ctx (parse-string code))
+          (is (= '{:ns                clojure.test
+                   :name              deftest
+                   :unresolved?       true
+                   :clojure-excluded? false}
+                 (resolve-name ctx 'clj-kondo.impl.utils 'deftest))))
+        (let [ctx (new-ctx)]
+          (analyze-ns-decl ctx (parse-string code))
+          (is (= '{:ns clojure.string
+                   :name blank?
+                   :unresolved? true
+                   :clojure-excluded? false}
+                 (resolve-name ctx 'clj-kondo.impl.utils 'blank?))))))))
 
 (comment
   (t/run-tests)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2126,7 +2126,15 @@ foo/foo ;; this does use the private var
           {:linters {:refer-all {:level :warning}
                      :use {:level :warning}}}))
   (is (empty? (lint! "(require '[clojure.test :refer :all])"
-                     '{:linters {:refer-all {:level :warning :exclude [clojure.test]}}}))))
+                     '{:linters {:refer-all {:level :warning :exclude [clojure.test]}}})))
+  (is (empty? (lint! (io/file "corpus" "deftest_resolve_test_name_pass.clj")
+                     '{:linters {:unresolved-symbol {:level :error}
+                                 :refer-all {:level :warning
+                                             :exclude [clojure.test clojure.string]}}})))
+  (is (empty? (lint! (io/file "corpus" "deftest_resolve_test_name_fail.clj")
+                     '{:linters {:unresolved-symbol {:level :error}
+                                 :refer-all {:level :warning
+                                             :exclude [clojure.test clojure.string]}}}))))
 
 (deftest canonical-paths-test
   (testing "single file"


### PR DESCRIPTION
Fix for deftest false positive unresolved-symbol with more than one :refer :all requires.

There's a little hardcoding that I think needs to happen here, due to the lack of info we get when :refer :all is used. I'd be happy to add this to the config options if you'd like, but as we discussed, it's so nuanced that that's probably overkill.

Lmk what changes might be needed and I'll be happy to fix.