### PR TITLE
Allow ignore unused :as binding.

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -116,7 +116,9 @@
          skip-reg-binding? (or skip-reg-binding?
                                (when (and keys-destructuring? fn-args?)
                                  (-> ctx :config :linters :unused-binding
-                                     :exclude-destructured-keys-in-fn-args)))]
+                                     :exclude-destructured-keys-in-fn-args)))
+         exclude-unused-as? (-> ctx :config :linters :unused-binding
+                                    :exclude-unused-as)]
      (case t
        :token
        (cond
@@ -136,7 +138,7 @@
                                 :name s
                                 :filename (:filename ctx)
                                 :tag t)]
-                   (when-not skip-reg-binding?
+                   (when-not (or skip-reg-binding? exclude-unused-as?)
                      (namespace/reg-binding! ctx
                                              (-> ctx :ns :name)
                                              v))
@@ -1844,5 +1846,4 @@
 ;;;; Scratch
 
 (comment
-  (parse-string "#js [1 2 3]")
-  )
+  (parse-string "#js [1 2 3]"))

--- a/test/clj_kondo/unused_bindings_test.clj
+++ b/test/clj_kondo/unused_bindings_test.clj
@@ -259,4 +259,19 @@
     (is (empty? (lint! "(defn f [{:keys [:a] :or {a 1}}] nil)"
                        '{:linters {:unused-binding
                                    {:level :warning
-                                    :exclude-destructured-keys-in-fn-args true}}})))))
+                                    :exclude-destructured-keys-in-fn-args true}}}))))
+  (testing "respects the :exclude-unused-as as true setting from the "
+    (is (empty? (lint! "(defn f [{:keys [:a] :as config}] a)"
+                       '{:linters {:unused-binding
+                                   {:level :warning
+                                    :exclude-unused-as true}}}))))
+  (testing "respects the :exclude-unused-as as false setting from the "
+    (assert-submaps '({:file "<stdin>"
+                       :row 1
+                       :col 26
+                       :level :warning
+                       :message "unused binding config"})
+                    (lint! "(defn f [{:keys [:a] :as config}] a)"
+                           '{:linters {:unused-binding
+                                       {:level :warning
+                                        :exclude-unused-as false}}}))))


### PR DESCRIPTION
It is sometimes useful to include the `:as` when destructuring maps because it
can help to identify similarily named functions, but with different inputs,
and thus acts as a form of documentation.

For example:

(defn foo [{:keys [bar] :as config}] bar)

Whilst `config` is not used, it is at least documented and easy to spot when
scanning through the code.

This commit, which closes #1016, introduces a new exclude-binding option
called `exclude-unused-as` which, when set to true, will tell the linter to
ignore any unused :as bindings.

-=david=-