### PR TITLE
[#1016] option to exclude :as from unused bindings

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -348,6 +348,28 @@ $ echo '(defn f [{:keys [:a :b :c]} _d])' | clj-kondo --lint - --config \
 linting took 8ms, errors: 0, warnings: 0
 ```
 
+The exclude the `:as` binding from being reported (which can be useful for
+self-documenting some code), use:
+
+```clojure
+{:linters {:unused-binding {:exclude-unused-as true}}}
+```
+
+Examples:
+
+```clojure
+$ echo '(defn f [{:keys [a b c] :as g}] a b c)' | clj-kondo --lint - --config \
+  '{:linters {:unused-binding {:exclude-destructured-as false}}}'
+<stdin>:1:29: warning: unused binding g
+linting took 46ms, errors: 0, warnings: 1
+```
+
+```clojure
+$ echo '(defn f [{:keys [a b c] :as g}] a b c)' | clj-kondo --lint - --config \
+  '{:linters {:unused-binding {:exclude-destructured-as true}}}'
+linting took 56ms, errors: 0, warnings: 0
+```
+
 ### Exclude unused private vars from being reported
 
 Example code:
@@ -732,6 +754,6 @@ These are some example configurations used in real projects. Feel free to create
 
 ## Deprecations
 
-Some configuration keys have been renamed over time. The default configuration is always up-to-date and we strive to mantain backwards compatibility. However, for completeness, you can find a list of the renamed keys here. 
+Some configuration keys have been renamed over time. The default configuration is always up-to-date and we strive to mantain backwards compatibility. However, for completeness, you can find a list of the renamed keys here.
 
 - `:if -> :missing-else-branch`

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -138,7 +138,7 @@
                                 :name s
                                 :filename (:filename ctx)
                                 :tag t)]
-                   (when-not (or skip-reg-binding? exclude-destructured-as?)
+                   (when-not (and skip-reg-binding? exclude-destructured-as?)
                      (namespace/reg-binding! ctx
                                              (-> ctx :ns :name)
                                              v))
@@ -221,7 +221,9 @@
                                (recur rest-kvs res))
                              ;; analyze or after the rest
                              (recur (concat rest-kvs [k v]) res))
-                           :as (recur rest-kvs (merge res (extract-bindings ctx v opts)))
+                           :as (if exclude-destructured-as?
+                                (recur rest-kvs (merge res (extract-bindings (assoc ctx :skip-reg-binding? true) v opts)))
+                                (recur rest-kvs (merge res (extract-bindings ctx v opts))))
                            (recur rest-kvs res)))
                        :else
                        (recur rest-kvs (merge res (extract-bindings ctx k opts)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -116,7 +116,9 @@
          skip-reg-binding? (or skip-reg-binding?
                                (when (and keys-destructuring? fn-args?)
                                  (-> ctx :config :linters :unused-binding
-                                     :exclude-destructured-keys-in-fn-args)))]
+                                     :exclude-destructured-keys-in-fn-args)))
+         exclude-destructured-as? (-> ctx :config :linters :unused-binding
+                                          :exclude-destructured-as)]
      (case t
        :token
        (cond
@@ -136,7 +138,7 @@
                                 :name s
                                 :filename (:filename ctx)
                                 :tag t)]
-                   (when-not skip-reg-binding?
+                   (when-not (or skip-reg-binding? exclude-destructured-as?)
                      (namespace/reg-binding! ctx
                                              (-> ctx :ns :name)
                                              v))
@@ -1844,5 +1846,4 @@
 ;;;; Scratch
 
 (comment
-  (parse-string "#js [1 2 3]")
-  )
+  (parse-string "#js [1 2 3]"))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -138,7 +138,7 @@
                                 :name s
                                 :filename (:filename ctx)
                                 :tag t)]
-                   (when-not (and skip-reg-binding? exclude-destructured-as?)
+                   (when-not (or skip-reg-binding? exclude-destructured-as?)
                      (namespace/reg-binding! ctx
                                              (-> ctx :ns :name)
                                              v))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -116,9 +116,7 @@
          skip-reg-binding? (or skip-reg-binding?
                                (when (and keys-destructuring? fn-args?)
                                  (-> ctx :config :linters :unused-binding
-                                     :exclude-destructured-keys-in-fn-args)))
-         exclude-destructured-as? (-> ctx :config :linters :unused-binding
-                                          :exclude-destructured-as)]
+                                     :exclude-destructured-keys-in-fn-args)))]
      (case t
        :token
        (cond
@@ -138,7 +136,7 @@
                                 :name s
                                 :filename (:filename ctx)
                                 :tag t)]
-                   (when-not (or skip-reg-binding? exclude-destructured-as?)
+                   (when-not skip-reg-binding?
                      (namespace/reg-binding! ctx
                                              (-> ctx :ns :name)
                                              v))
@@ -221,7 +219,8 @@
                                (recur rest-kvs res))
                              ;; analyze or after the rest
                              (recur (concat rest-kvs [k v]) res))
-                           :as (if exclude-destructured-as?
+                           :as (if (-> ctx :config :linters :unused-binding
+                                       :exclude-destructured-as)
                                 (recur rest-kvs (merge res (extract-bindings (assoc ctx :skip-reg-binding? true) v opts)))
                                 (recur rest-kvs (merge res (extract-bindings ctx v opts))))
                            (recur rest-kvs res)))

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -32,13 +32,15 @@
               :datalog-syntax {:level :error}
               :unbound-destructuring-default {:level :warning}
               :unused-binding {:level :warning
-                               :exclude-destructured-keys-in-fn-args false}
+                               ;;:exclude-destructured-keys-in-fn-args false
+                               ;;:exclude-destructred-as false
+                               ,}
               :unsorted-required-namespaces {:level :off}
               :unused-namespace {:level :warning
                                  ;; don't warn about these namespaces:
-                                 :exclude [#_clj-kondo.impl.var-info-gen]
+                                 :exclude [#_clj-kondo.impl.var-info-gen]}
                                  ;; :simple-libspec true
-                                 }
+
               :unresolved-symbol {:level :error
                                   :exclude [;; ignore globally:
                                             #_js*
@@ -52,9 +54,9 @@
                                             (clojure.test/is [thrown? thrown-with-msg?])
                                             (cljs.test/is [thrown? thrown-with-msg?])]}
               :unresolved-namespace {:level :warning
-                                     :exclude [#_foo.bar
+                                     :exclude [#_foo.bar]}
                                                ;; for example: foo.bar is always loaded in a user profile
-                                               ]}
+
               :misplaced-docstring {:level :warning}
               :not-empty? {:level :warning}
               :deprecated-var {:level :warning
@@ -109,8 +111,8 @@
              ;; the output pattern can be altered using a template. use {{LEVEL}} to print the level in capitals.
              ;; the default template looks like this:
              ;; :pattern "{{filename}}:{{row}}:{{col}}: {{level}}: {{message}}"
-             :canonical-paths false ;; set to true to see absolute file paths and jar files
-             }})
+             :canonical-paths false}}) ;; set to true to see absolute file paths and jar files
+
 
 (defn merge-config!
   ([])
@@ -186,7 +188,7 @@
         delayed-cfg (memoize delayed-cfg)]
     (fn [config ns-sym var-sym]
       (let [excluded (delayed-cfg config)]
-        (when-let [vars (get excluded ns-sym )]
+        (when-let [vars (get excluded ns-sym)]
           (contains? vars var-sym))))))
 
 (def unresolved-namespace-excluded
@@ -285,5 +287,4 @@
 
 ;;;; Scratch
 
-(comment
-  )
+(comment)

--- a/test/clj_kondo/unused_bindings_test.clj
+++ b/test/clj_kondo/unused_bindings_test.clj
@@ -255,81 +255,56 @@
                     (lint! "(let [{:keys [:i] :or {i 2}} {}] nil)"
                            '{:linters
                              {:unused-binding {:level :warning}}})))
-  (testing "respects the :exclude-destructured-keys-in-fn-args setting from the "
+  (testing "respects :exclude-destructured-keys-in-fn-args setting "
     (is (empty? (lint! "(defn f [{:keys [:a] :or {a 1}}] nil)"
                        '{:linters {:unused-binding
                                    {:level :warning
                                     :exclude-destructured-keys-in-fn-args true}}}))))
-  (testing "respects the :exclude-destructured-as as true setting from the "
+  (testing "respects :exclude-destructured-as "
     (is (empty? (lint! "(defn f [{:keys [:a] :as config}] a)"
                        '{:linters {:unused-binding
                                    {:level :warning
-                                    :exclude-destructured-as true}}}))))
-  (testing "respects the :exclude-destructured-as as true and also shows unused other bindings setting from the "
-    (assert-submaps '({:file "<stdin>"
-                       :row 1
-                       :col 18
-                       :level :warning
-                       :message "unused binding a"})
-                    (lint! "(defn f [{:keys [:a] :as config}] nil)"
-                       '{:linters {:unused-binding
-                                   {:level :warning
-                                    :exclude-destructured-as true}}}))
-    (assert-submaps '({:file "<stdin>"
-                       :row 1
-                       :col 18
-                       :level :warning
-                       :message "unused binding a"})
-                    (lint! "(defn f [{:keys [:a] :as config}] config)"
-                       '{:linters {:unused-binding
-                                   {:level :warning
-                                    :exclude-destructured-as true}}}))
-    (assert-submaps '({:file "<stdin>"
-                       :row 1
-                       :col 10
-                       :level :warning
-                       :message "unused binding x"}
-                      {:file "<stdin>"
-                       :row 1
-                       :col 12
-                       :level :warning
-                       :message "unused binding y"}
-                      {:file "<stdin>"
-                       :row 1
-                       :col 14
-                       :level :warning
-                       :message "unused binding z"}
-                      {:file "<stdin>"
-                       :row 1
-                       :col 24
-                       :level :warning
-                       :message "unused binding a"})
-                    (lint! "(defn f [x y z {:keys [:a] :as g}] g)"
-                       '{:linters {:unused-binding
-                                   {:level :warning
                                     :exclude-destructured-as true}}})))
-  (testing "respects the :exclude-destructured-as as false setting from the "
-    (assert-submaps '({:file "<stdin>"
-                       :row 1
-                       :col 26
-                       :level :warning
-                       :message "unused binding config"})
-                    (lint! "(defn f [{:keys [:a] :as config}] a)"
-                           '{:linters {:unused-binding
-                                       {:level :warning
-                                        :exclude-destructured-as false}}})))
-  (testing "respects the :exclude-destructured-as as false setting and also shows all unused bindings from the "
-    (assert-submaps '({:file "<stdin>"
-                       :row 1
-                       :col 18
-                       :level :warning
-                       :message "unused binding a"}
-                      {:file "<stdin>"
-                       :row 1
-                       :col 26
-                       :level :warning
-                       :message "unused binding config"})
-                    (lint! "(defn f [{:keys [:a] :as config}] nil)"
-                           '{:linters {:unused-binding
-                                       {:level :warning
-                                        :exclude-destructured-as false}}}))))
+    (testing "still shows unused bindings not in as "
+      (assert-submaps '({:file "<stdin>"
+                         :row 1
+                         :col 18
+                         :level :warning
+                         :message "unused binding a"})
+                      (lint! "(defn f [{:keys [:a] :as config}] nil)"
+                             '{:linters {:unused-binding
+                                         {:level :warning
+                                          :exclude-destructured-as true}}}))
+      (assert-submaps '({:file "<stdin>"
+                         :row 1
+                         :col 18
+                         :level :warning
+                         :message "unused binding a"})
+                      (lint! "(defn f [{:keys [:a] :as config}] config)"
+                             '{:linters {:unused-binding
+                                         {:level :warning
+                                          :exclude-destructured-as true}}}))
+      (assert-submaps '({:file "<stdin>"
+                         :row 1
+                         :col 10
+                         :level :warning
+                         :message "unused binding x"}
+                        {:file "<stdin>"
+                         :row 1
+                         :col 12
+                         :level :warning
+                         :message "unused binding y"}
+                        {:file "<stdin>"
+                         :row 1
+                         :col 14
+                         :level :warning
+                         :message "unused binding z"}
+                        {:file "<stdin>"
+                         :row 1
+                         :col 24
+                         :level :warning
+                         :message "unused binding a"})
+                      (lint! "(defn f [x y z {:keys [:a] :as g}] g)"
+                             '{:linters {:unused-binding
+                                         {:level :warning
+                                          :exclude-destructured-as true}}})))))

--- a/test/clj_kondo/unused_bindings_test.clj
+++ b/test/clj_kondo/unused_bindings_test.clj
@@ -283,6 +283,30 @@
                     (lint! "(defn f [{:keys [:a] :as config}] config)"
                        '{:linters {:unused-binding
                                    {:level :warning
+                                    :exclude-destructured-as true}}}))
+    (assert-submaps '({:file "<stdin>"
+                       :row 1
+                       :col 10
+                       :level :warning
+                       :message "unused binding x"}
+                      {:file "<stdin>"
+                       :row 1
+                       :col 12
+                       :level :warning
+                       :message "unused binding y"}
+                      {:file "<stdin>"
+                       :row 1
+                       :col 14
+                       :level :warning
+                       :message "unused binding z"}
+                      {:file "<stdin>"
+                       :row 1
+                       :col 24
+                       :level :warning
+                       :message "unused binding a"})
+                    (lint! "(defn f [x y z {:keys [:a] :as g}] g)"
+                       '{:linters {:unused-binding
+                                   {:level :warning
                                     :exclude-destructured-as true}}})))
   (testing "respects the :exclude-destructured-as as false setting from the "
     (assert-submaps '({:file "<stdin>"

--- a/test/clj_kondo/unused_bindings_test.clj
+++ b/test/clj_kondo/unused_bindings_test.clj
@@ -259,4 +259,53 @@
     (is (empty? (lint! "(defn f [{:keys [:a] :or {a 1}}] nil)"
                        '{:linters {:unused-binding
                                    {:level :warning
-                                    :exclude-destructured-keys-in-fn-args true}}})))))
+                                    :exclude-destructured-keys-in-fn-args true}}}))))
+  (testing "respects the :exclude-destructured-as as true setting from the "
+    (is (empty? (lint! "(defn f [{:keys [:a] :as config}] a)"
+                       '{:linters {:unused-binding
+                                   {:level :warning
+                                    :exclude-destructured-as true}}}))))
+  (testing "respects the :exclude-destructured-as as true and also shows unused other bindings setting from the "
+    (assert-submaps '({:file "<stdin>"
+                       :row 1
+                       :col 18
+                       :level :warning
+                       :message "unused binding a"})
+                    (lint! "(defn f [{:keys [:a] :as config}] nil)"
+                       '{:linters {:unused-binding
+                                   {:level :warning
+                                    :exclude-destructured-as true}}}))
+    (assert-submaps '({:file "<stdin>"
+                       :row 1
+                       :col 18
+                       :level :warning
+                       :message "unused binding a"})
+                    (lint! "(defn f [{:keys [:a] :as config}] config)"
+                       '{:linters {:unused-binding
+                                   {:level :warning
+                                    :exclude-destructured-as true}}})))
+  (testing "respects the :exclude-destructured-as as false setting from the "
+    (assert-submaps '({:file "<stdin>"
+                       :row 1
+                       :col 26
+                       :level :warning
+                       :message "unused binding config"})
+                    (lint! "(defn f [{:keys [:a] :as config}] a)"
+                           '{:linters {:unused-binding
+                                       {:level :warning
+                                        :exclude-destructured-as false}}})))
+  (testing "respects the :exclude-destructured-as as false setting and also shows all unused bindings from the "
+    (assert-submaps '({:file "<stdin>"
+                       :row 1
+                       :col 18
+                       :level :warning
+                       :message "unused binding a"}
+                      {:file "<stdin>"
+                       :row 1
+                       :col 26
+                       :level :warning
+                       :message "unused binding config"})
+                    (lint! "(defn f [{:keys [:a] :as config}] nil)"
+                           '{:linters {:unused-binding
+                                       {:level :warning
+                                        :exclude-destructured-as false}}}))))


### PR DESCRIPTION
By @dharrigan:

It is sometimes useful to include the `:as` when destructuring maps because it
can help to identify similarily named functions, but with different inputs,
and thus acts as a form of documentation.

For example:

`(defn foo [{:keys [bar] :as config}] bar)`

Whilst `config` is not used, it is at least documented and easy to spot when
scanning through the code.

This commit, which solves #1016, introduces a new exclude-binding option
called `exclude-destructured-as` which, when set to true, will tell the linter to
ignore any unused :as bindings.