### PR TITLE
Adding install instructions for using the repositories and the AppImage.

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -3,7 +3,11 @@
 ## Manual install
 
 Pre-built binaries are available for linux and MacOS <!-- and Windows -->on the
-[releases](https://github.com/borkdude/clj-kondo/releases) page.
+[releases](https://github.com/borkdude/clj-kondo/releases) page. Repositories
+for various Linux distributions can be found
+[here](https://software.opensuse.org//download.html?project=home%3Azilti%3Aclojure&package=clj-kondo)
+and there is also an
+[updateable AppImage](https://download.opensuse.org/repositories/home:/zilti:/clojure/AppImage/clj-kondo-latest-x86_64.AppImage).
 
 ## Installation script (MacOS and Linux)
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -8,6 +8,8 @@ for various Linux distributions can be found
 [here](https://software.opensuse.org//download.html?project=home%3Azilti%3Aclojure&package=clj-kondo)
 and there is also an
 [updateable AppImage](https://download.opensuse.org/repositories/home:/zilti:/clojure/AppImage/clj-kondo-latest-x86_64.AppImage).
+If you use the AppImage, simply save the file as "clj-kondo" and make it executable.
+It is fully self-contained - without the overhead that comes with Docker!
 
 ## Installation script (MacOS and Linux)
 


### PR DESCRIPTION
Adding install instructions for using the repositories and the AppImage.

FYI, it also generates a Docker image. I don't use Docker, but it gave the following info along with it:

```
This container can be pulled via:
  docker pull registry.opensuse.org/home/zilti/clojure/containers/clj-kondo:latest

Set DOCKER_CONTENT_TRUST=1 to enable image tag verification.
```