### PR TITLE
[#1042] fix format false positive on relative indexing

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1195,7 +1195,7 @@
         (reduce (fn [[indexed unindexed] percent]
                   (if-let [[_ pos] (re-find #"^%(\d+)\$" percent)]
                     [(max indexed (Integer/parseInt pos)) unindexed]
-                    [indexed (cond-> unindexed (not= (nth percent 1) \<) inc)]))
+                    [indexed (cond-> unindexed (not= (.charAt ^String percent 1) \<) inc)]))
                 [0 0] percents)
         percent-count (max indexed unindexed)
         arg-count (count args)]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1195,7 +1195,8 @@
         (reduce (fn [[indexed unindexed] percent]
                   (if-let [[_ pos] (re-find #"^%(\d+)\$" percent)]
                     [(max indexed (Integer/parseInt pos)) unindexed]
-                    [indexed (inc unindexed)])) [0 0] percents)
+                    [indexed (cond-> unindexed (not= (nth percent 1) \<) inc)]))
+                [0 0] percents)
         percent-count (max indexed unindexed)
         arg-count (count args)]
     (when-not (= percent-count

--- a/test/clj_kondo/format_test.clj
+++ b/test/clj_kondo/format_test.clj
@@ -20,6 +20,9 @@
   (is (empty? (lint! "(format \"%3$s\" 1 2 3)")))
   (is (empty? (lint! "(format \"%3$s %s %s %s\" 1 2 3)")))
   (is (empty? (lint! "(format \"%3$s %s %s %s %s\" 1 2 3 4)")))
+  (is (empty? (lint! "(format \"%s %<s\" 1)")))
+  (is (empty? (lint! "(format \"%s %<s %s\" 1 2)")))
+  (is (empty? (lint! "(format \"%s %2$ %<s %s\" 1 2)")))
   (is (empty? (lint! "(defn foo [x] (format x 1))")))
   (is (empty? (lint! "
 (ns foo {:clj-kondo/config '{:linters {:format {:level :off}}}})


### PR DESCRIPTION
Fixes #1042.

Output of `script/diff`:
```
-R is deprecated, use -A with repl, -M for main, or -X for exec
Linting and writing output to /tmp/clj-kondo-diff/branch.txt
WARNING: When invoking clojure.main, use -M
Cloning into 'clj-kondo'...
remote: Enumerating objects: 239, done.
remote: Counting objects: 100% (239/239), done.
remote: Compressing objects: 100% (159/159), done.
remote: Total 9109 (delta 109), reused 150 (delta 59), pack-reused 8870
Receiving objects: 100% (9109/9109), 10.93 MiB | 1.03 MiB/s, done.
Resolving deltas: 100% (5220/5220), done.
Linting and writing output to /tmp/clj-kondo-diff/master.txt
WARNING: Use of :main-opts with -A is deprecated. Use -M instead.
WARNING: When invoking clojure.main, use -M
1c1
< "Elapsed time: 11.48637 msecs"
---
> "Elapsed time: 10.536513 msecs"
3425c3425
< linting took 12683ms, errors: 399, warnings: 3024
---
> linting took 12621ms, errors: 399, warnings: 3024
```