### PR TITLE
Include namespace and name in unused-refer findings

### DIFF
--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -389,7 +389,9 @@
                   (config/unused-referred-var-excluded config var-ns k))
             (findings/reg-finding!
              ctx
-             (node->line filename k :warning :unused-referred-var (str "#'" var-ns "/" (:name v) " is referred but never used"))))))
+             (-> (node->line filename k :warning :unused-referred-var (str "#'" var-ns "/" (:name v) " is referred but never used"))
+                 (assoc :ns var-ns
+                        :name (:name v)))))))
       (doseq [[referred-all-ns {:keys [:referred :node]}] refer-alls
               :when (not (config/refer-all-excluded? config referred-all-ns))]
         (let [{:keys [:k :value]} node


### PR DESCRIPTION
Extends the findings for :unused-referred-vars to include the namespace and name of the unused variable.

The impetus for this is reporting and removing unused-refers in [carve](https://github.com/borkdude/carve) - hopefully a PR for that will be along after this.

This was not testable via `lint!`, which parses the linter output for metadata. (name and namespace are not included in that output)