### PR TITLE
circleci: remove jvm job step "create uberjar" and store compiled -standalone.jar per platform as artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,16 +40,6 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "deps.edn" }}
-      - run:
-          name: Create uberjar
-          command: |
-            mkdir -p /tmp/release
-            lein do clean, uberjar
-            VERSION=$(cat resources/CLJ_KONDO_VERSION)
-            cp target/clj-kondo-$VERSION-standalone.jar /tmp/release
-      - store_artifacts:
-          path: /tmp/release
-          destination: release
 
   linux:
     docker:

--- a/.circleci/script/release
+++ b/.circleci/script/release
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 rm -rf /tmp/release
 mkdir -p /tmp/release
 cp clj-kondo /tmp/release
 cp performance.txt /tmp/release
 VERSION=$(cat resources/CLJ_KONDO_VERSION)
+cp target/clj-kondo-$VERSION-standalone.jar /tmp/release
 
 cd /tmp/release
 


### PR DESCRIPTION
I was unable to native-image the previously generated standalone.jar with graalvm8-20.2 or with graalvm11-20.2.

I've not changed the circleci run steps to use script/compile because I didn't want to change too much around.

Both +clj-1.10.2 and +native-image have to be enabled for it to work, otherwise there are different errors.
(I could provide logs if this is of interest.)